### PR TITLE
Improve NeoForge metadata configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,40 @@
-# Origins (Forge)
+# Tectonic Expanded (NeoForge)
 
-This is the repository that is used to build Origins Forge.
+This repository contains the NeoForge build logic for the **Tectonic Expanded** mod. The
+project targets Minecraft **1.21.1** on NeoForge **21.1.209** and is configured to build
+with Gradle **8.13** and a Java **21** toolchain.
 
-## Building
+## Requirements
 
-To build this repository, first clone it, preferably with the `--recurse-submodules` flag.
+* Java Development Kit 21 (the project configures the toolchain automatically, but a JDK
+  installation is still required for Gradle to download the matching version).
+* Gradle Wrapper (included); invoke the wrapper scripts instead of a system Gradle.
 
-Then run `gradlew build` in the root directory. The build output is the `unified` jar file.
+## Building from source
 
-## Creating addons
+1. Clone the repository.
+2. (Optional) Update the values in `gradle.properties` to customise the mod metadata or
+   target versions.
+3. Run the build using the Gradle wrapper:
 
-The simplest way to load Origins in a dev environment is currently to use
-[Curse Maven](https://www.cursemaven.com/). Do do so, add the flowing to your
-gradle build script:
-```gradle
-repositories {
-    ...
-    maven {
-        url "https://cursemaven.com"
-        content {
-            includeGroup "curse.maven"
-        }
-    }
-}
+   ```bash
+   ./gradlew --console=plain build
+   ```
 
-dependencies {
-    ...
-    implementation fg.deobf("curse.maven:origins-474438:<fileid>")
-}
-```
+   The resulting NeoForge mod jar is written to `build/libs/`.
 
-You can find file ids on [CurseForge](https://www.curseforge.com/minecraft/mc-mods/origins-forge/files).
+During the build the `neoforge.mods.toml` files located in `src/main/resources` and in any
+version-specific source sets are automatically expanded with the values defined in
+`gradle.properties`. This ensures the published jar always advertises the correct mod id,
+version, and dependency ranges.
 
-### Changes from fabric
-Apoli for forge is partial rewrite of the fabric version, as such many compatiblity features
-are currently missing. Furthermore, due to a mistake during the porting process, powers for
-forge take Entities as argument instead of LivingEntities.
+## Updating Minecraft or NeoForge versions
 
-To register a power on forge, you'll need to use the regular forge process, either
-with `RegistryEvent.Register` or `DeferredRegister`.
+The default Minecraft and NeoForge versions are controlled by the `minecraftVersion` and
+`neoForgeVersion` entries in `gradle.properties`. When bumping either value, also update
+the corresponding version ranges (`minecraftVersionRange`, `neoForgeVersionRange`) so the
+generated `neoforge.mods.toml` continues to match the desired compatibility matrix.
 
-The registry types apoli forge uses are all defined in the package `io.github.edwinmindcraft.apoli.api.power.factory`.
-If you want to use `DeferredRegister`, as classes are generics, consider using types
-provided in `ApoliRegistries`.
-
-While defining a power, action or condition the same way as fabric is possible,
-if you are developing a pure forge addon, I would recommend using Mojang's `Codec`
-system as well as `records` for static data storage as the system currently has builtin
-support for error logging on those.
-
-The system currently implemented is similar to the vanilla's Feature/ConfiguredFeature system, which
-means most data will not change from one entity to another. If you do need to change data internally,
-forge provides `ConfiguredPower.getPowerData` that will store any **mutable** data structure on the entity.
-
-Other important changes:
-* `ActionFactory` and `ConditionFactory` were split for each given subtype.
-* When fabric used `Predicate` or `Consumer`, you'll need to use the matching `ConfiguredCondition` or `ConfiguredAction`
-* Codecs are provided for most types, either in the class itself, or in the same places
-as fabric `SerializableDataTypes` and `ApoliDataTypes`.
-* Prefer using `CalioCodecHelper.optionalField` over `Codec.optionalFieldOf` 
-  since those field will properly handle error logging.
-* Prefer using `CalioCodecHelper.listOf` over `Codec.listOf` since those lists
-  support the calio format of list.
-* `SerializableDataTypes` can be used as `Codecs` of the same type.
-* `SerializableData` can be used a `MapCodecs` of the same type.
-* `PowerFactories` can by default be conditioned.
-
-### Defining a new content
-
-To define a new power, action or condition, you'll need a configuration which
-implements `IDynamicFeatureConfiguration`. While this class doesn't have any
-abstract methods, you can still override the methods provided to display additional
-information in the logs for people defining datapacks using your content.
+If you need to produce builds for multiple Minecraft releases, the `versions/` directory
+contains per-version resource overrides. Add or adjust files within the appropriate
+sub-directory to customise metadata or assets for that specific target.

--- a/build.gradle
+++ b/build.gradle
@@ -5,13 +5,25 @@ plugins {
     id 'net.neoforged.gradle.userdev' version '7.0.190'
 }
 
-group = 'com.example'
+group = project.findProperty('maven_group') ?: 'com.example'
 
-def mod_version = project.findProperty("mod_version") ?: "2.0.0"
-def minecraft_version = project.findProperty("minecraftVersion") ?: "1.21.1"
+def mod_version = project.findProperty('mod_version') ?: '2.0.0'
+def minecraft_version = project.findProperty('minecraftVersion') ?: '1.21.1'
+def neoForge_version = project.findProperty('neoForgeVersion') ?: '21.1.209'
+def mod_id = project.findProperty('mod_id') ?: 'tectonicexpanded'
+def mod_name = project.findProperty('mod_name') ?: 'Tectonic Expanded'
+def mod_authors = project.findProperty('mod_authors') ?: 'CyberDay1'
+def mod_license = project.findProperty('mod_license') ?: 'MIT'
+def mod_description = project.findProperty('mod_description') ?: 'Expanded tectonic worldgen'
+def loader_version_range = project.findProperty('loaderVersionRange') ?: '[2,)'
+def neoForge_version_range = project.findProperty('neoForgeVersionRange') ?: "[${neoForge_version},)"
+def minecraft_version_range = project.findProperty('minecraftVersionRange') ?: "[${minecraft_version},${minecraft_version}]"
 
 version = "${mod_version}+mc${minecraft_version}-neoforge"
-archivesBaseName = 'TectonicExpanded'
+
+base {
+    archivesName = mod_name.replaceAll(/\s+/, '')
+}
 
 java {
     toolchain {
@@ -26,7 +38,7 @@ repositories {
 }
 
 dependencies {
-    implementation "net.neoforged:neoforge:${neoForgeVersion}"
+    implementation "net.neoforged:neoforge:${neoForge_version}"
     implementation 'com.google.guava:guava:31.1-jre'
 }
 
@@ -37,8 +49,23 @@ tasks.withType(JavaCompile).configureEach {
 
 tasks.withType(ProcessResources).configureEach {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    filesMatching("META-INF/neoforge.mods.toml") {
-        expand("mod_version": mod_version)
+
+    def expandProps = [
+        mod_id                 : mod_id,
+        mod_name               : mod_name,
+        mod_version            : mod_version,
+        mod_authors            : mod_authors,
+        mod_license            : mod_license,
+        mod_description        : mod_description,
+        loaderVersionRange     : loader_version_range,
+        neoForgeVersionRange   : neoForge_version_range,
+        minecraftVersionRange  : minecraft_version_range
+    ]
+
+    inputs.properties(expandProps)
+
+    filesMatching('META-INF/neoforge.mods.toml') {
+        expand(expandProps)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,14 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 minecraftVersion=1.21.1
+minecraftVersionRange=[1.21.1,1.21.1]
 neoForgeVersion=21.1.209
+neoForgeVersionRange=[21.1.209,)
+loaderVersionRange=[2,)
 mod_version=2.0.0
+mod_id=tectonicexpanded
+mod_name=Tectonic Expanded
+mod_description=Expanded tectonic worldgen
+mod_authors=CyberDay1
+mod_license=MIT
+maven_group=com.cyberday1.tectonicexpanded

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,24 +1,24 @@
 modLoader="javafml"
-loaderVersion="[2,)"
-license="MIT"
+loaderVersion="${loaderVersionRange}"
+license="${mod_license}"
 
 [[mods]]
-modId="tectonicexpanded"
+modId="${mod_id}"
 version="${mod_version}"
-displayName="Tectonic Expanded"
-description="Expanded tectonic worldgen"
-authors="CyberDay1"
+displayName="${mod_name}"
+authors="${mod_authors}"
+description='''${mod_description}'''
 
-[[dependencies.origins]]
+[[dependencies.${mod_id}]]
 modId="neoforge"
 type="required"
-versionRange="[21.1.209,)"
+versionRange="${neoForgeVersionRange}"
 ordering="NONE"
 side="BOTH"
 
-[[dependencies.origins]]
+[[dependencies.${mod_id}]]
 modId="minecraft"
 type="required"
-versionRange="[1.21.1,1.21.1]"
+versionRange="${minecraftVersionRange}"
 ordering="NONE"
 side="BOTH"

--- a/versions/1.21.1-neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/versions/1.21.1-neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,10 +1,24 @@
 modLoader="javafml"
-loaderVersion="[2,)"
-license="MIT"
+loaderVersion="${loaderVersionRange}"
+license="${mod_license}"
 
 [[mods]]
-modId="tectonicexpanded"
+modId="${mod_id}"
 version="${mod_version}"
-displayName="Tectonic Expanded"
-description="Expanded tectonic worldgen"
-authors="CyberDay1"
+displayName="${mod_name}"
+authors="${mod_authors}"
+description='''${mod_description}'''
+
+[[dependencies.${mod_id}]]
+modId="neoforge"
+type="required"
+versionRange="${neoForgeVersionRange}"
+ordering="NONE"
+side="BOTH"
+
+[[dependencies.${mod_id}]]
+modId="minecraft"
+type="required"
+versionRange="${minecraftVersionRange}"
+ordering="NONE"
+side="BOTH"

--- a/versions/1.21.5-neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/versions/1.21.5-neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,10 +1,24 @@
 modLoader="javafml"
-loaderVersion="[2,)"
-license="MIT"
+loaderVersion="${loaderVersionRange}"
+license="${mod_license}"
 
 [[mods]]
-modId="tectonicexpanded"
+modId="${mod_id}"
 version="${mod_version}"
-displayName="Tectonic Expanded"
-description="Expanded tectonic worldgen"
-authors="CyberDay1"
+displayName="${mod_name}"
+authors="${mod_authors}"
+description='''${mod_description}'''
+
+[[dependencies.${mod_id}]]
+modId="neoforge"
+type="required"
+versionRange="${neoForgeVersionRange}"
+ordering="NONE"
+side="BOTH"
+
+[[dependencies.${mod_id}]]
+modId="minecraft"
+type="required"
+versionRange="${minecraftVersionRange}"
+ordering="NONE"
+side="BOTH"


### PR DESCRIPTION
## Summary
- expose mod identity, version range, and descriptive metadata through gradle.properties
- expand all neoforge.mods.toml descriptors using the shared metadata map during resource processing
- rewrite the README with updated build steps for the NeoForge toolchain

## Testing
- `./gradlew --console=plain jar`


------
https://chatgpt.com/codex/tasks/task_e_68db4a5040f0832791ddf20d25b175c3