### PR TITLE
Set up NeoForge Gradle build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,25 @@
-# gradle
-
+# Gradle
 .gradle/
 build/
 out/
 classes/
 
-# eclipse
-
-*.launch
-
-# idea
-
+# IDE
 .idea/
 *.iml
 *.ipr
 *.iws
-
-# vscode
-
-.settings/
 .vscode/
+.settings/
+*.launch
 bin/
 .classpath
 .project
 
-# fabric
-
+# Run directories
 run/
+runs/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-    id 'java'
-    id 'net.neoforged.gradle.userdev' version '7.0.190'
+    id "java"
+    id "net.neoforged.gradle.userdev" version "7.0.190"
 }
 
-group = 'com.example'
+group = "io.github.apace100"
 version = project.mod_version
-archivesBaseName = 'origins-neoforge'
+archivesBaseName = "origins-neoforge"
 
 java {
     toolchain {
@@ -14,14 +14,33 @@ java {
 }
 
 repositories {
-    mavenLocal()
-    maven { url = 'https://maven.neoforged.net/releases' }
     mavenCentral()
+    maven { url = "https://maven.neoforged.net/releases" }
 }
 
 dependencies {
+    // NeoForge API & dev env for compile; no separate 'userdev' block is used.
     implementation "net.neoforged:neoforge:${project.neoForgeVersion}"
-    implementation 'com.google.guava:guava:31.1-jre'
 }
 
-mappings channel: 'official', version: project.minecraftVersion
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = "UTF-8"
+    options.release = 21
+}
+
+processResources {
+    // Expand only the NeoForge descriptor with the mod version
+    filesMatching("META-INF/neoforge.mods.toml") {
+        expand(mod_version: project.mod_version)
+        filteringCharset = "UTF-8"
+    }
+}
+
+jar {
+    // Optional: attach license if present without failing
+    if (file("LICENSE").exists()) {
+        from("LICENSE") {
+            rename { "LICENSE_${archivesBaseName}" }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,7 @@
-org.gradle.jvmargs=-Xmx2G -XX:+UseG1GC -Dfile.encoding=UTF-8
-org.gradle.caching=true
-org.gradle.parallel=true
-org.gradle.daemon=true
+# JVM/Gradle
+org.gradle.jvmargs=-Xmx3G -Xms1G -XX:+UseG1GC -Dfile.encoding=UTF-8
 
+# Versions
 minecraftVersion=1.21.1
 neoForgeVersion=21.1.209
 mod_version=1.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,8 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven { url = 'https://maven.neoforged.net/releases' }
+        maven { url = "https://maven.neoforged.net/releases" }
+        mavenCentral()
     }
 }
 

--- a/src/main/java/io/github/apace100/origins/OriginsNeoForge.java
+++ b/src/main/java/io/github/apace100/origins/OriginsNeoForge.java
@@ -1,0 +1,10 @@
+package io.github.apace100.origins;
+
+import net.neoforged.fml.common.Mod;
+
+@Mod("origins")
+public final class OriginsNeoForge {
+    public OriginsNeoForge() {
+        // Minimal entrypoint. Add event bus hooks as needed.
+    }
+}

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,17 +1,19 @@
-modLoader = "javafml"
-loaderVersion = "[7,)"
-license = "MIT"
+modLoader="javafml"
+loaderVersion="[1,)"
+license="MIT"
+
 [[mods]]
-modId = "origins"
-version = "${mod_version}"
-displayName = "Origins (NeoForge)"
-authors = "Apace"
-description = '''
-An origins-style mod ported to NeoForge.
+modId="origins"
+version="${mod_version}"
+displayName="Origins (NeoForge)"
+authors="Apace100, Contributors"
+description='''
+Origins: Live as a supernatural being with unique traits.
 '''
+
 [[dependencies.origins]]
-modId = "neoforge"
-mandatory = true
-versionRange = "[21.1,)"
-ordering = "NONE"
-side = "BOTH"
+modId="neoforge"
+mandatory=true
+versionRange="[21.1,)"
+ordering="NONE"
+side="BOTH"


### PR DESCRIPTION
## Summary
- configure the Groovy-based NeoForge Gradle build and properties for Minecraft 1.21.1
- add the minimal NeoForge mod descriptor and entrypoint class
- update the Gradle wrapper and .gitignore for the simplified setup

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68dbd7050ec883279ae036f143805190