### PR TITLE
Bootstrap registries, config, networking, and data hooks

### DIFF
--- a/src/main/java/io/github/origins/command/OriginsCommands.java
+++ b/src/main/java/io/github/origins/command/OriginsCommands.java
@@ -1,18 +1,36 @@
 package io.github.origins.command;
 
+import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
 
 public final class OriginsCommands {
     private OriginsCommands() {
     }
 
     public static void register(IEventBus modBus) {
-        // Command registration hooks will be added in a future phase.
+        NeoForge.EVENT_BUS.addListener(OriginsCommands::onRegisterCommands);
     }
 
-    public static void registerCommands(Commands.CommandSelection selection, CommandSourceStack source) {
-        // Commands will be registered in a future phase.
+    private static void onRegisterCommands(RegisterCommandsEvent event) {
+        register(event.getDispatcher());
+    }
+
+    private static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(
+            Commands.literal("origins")
+                .requires(source -> source.hasPermission(2))
+                .executes(context -> {
+                    context.getSource().sendSuccess(
+                        () -> Component.translatable("commands.origins.reload_soon"),
+                        true
+                    );
+                    return 1;
+                })
+        );
     }
 }

--- a/src/main/java/io/github/origins/config/ModConfigs.java
+++ b/src/main/java/io/github/origins/config/ModConfigs.java
@@ -1,12 +1,58 @@
 package io.github.origins.config;
 
+import io.github.origins.Origins;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModLoadingContext;
+import net.neoforged.fml.config.ModConfig;
+import net.neoforged.neoforge.common.ModConfigSpec;
+import net.neoforged.neoforge.event.ModConfigEvent;
 
 public final class ModConfigs {
+    public static final ModConfigSpec COMMON_SPEC;
+    public static final Common COMMON;
+
+    static {
+        ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
+        COMMON = new Common(builder);
+        COMMON_SPEC = builder.build();
+    }
+
     private ModConfigs() {
     }
 
     public static void register(IEventBus modBus) {
-        // Configuration registration will be added in a future phase.
+        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, COMMON_SPEC, Origins.MOD_ID + "-common.toml");
+        modBus.addListener(ModConfigs::handleConfigReload);
+    }
+
+    private static void handleConfigReload(ModConfigEvent event) {
+        if (event.getConfig().getSpec() == COMMON_SPEC) {
+            COMMON.reload();
+        }
+    }
+
+    public static final class Common {
+        public final ModConfigSpec.BooleanValue syncPowersOnLogin;
+        public final ModConfigSpec.IntValue maxTrackedPowers;
+
+        private Common(ModConfigSpec.Builder builder) {
+            builder.push("networking");
+            syncPowersOnLogin = builder
+                .comment(
+                    "If true, Origins will request a full power sync from the server whenever a player joins."
+                )
+                .define("syncPowersOnLogin", true);
+            builder.pop();
+
+            builder.push("gameplay");
+            maxTrackedPowers = builder
+                .comment("Hard limit for the number of simultaneous passive powers tracked on a player.")
+                .defineInRange("maxTrackedPowers", 32, 1, 128);
+            builder.pop();
+        }
+
+        private void reload() {
+            // Future hooks will consume updated config values.
+        }
     }
 }

--- a/src/main/java/io/github/origins/datagen/OriginsDataGenerators.java
+++ b/src/main/java/io/github/origins/datagen/OriginsDataGenerators.java
@@ -1,12 +1,21 @@
 package io.github.origins.datagen;
 
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.data.event.GatherDataEvent;
 
 public final class OriginsDataGenerators {
     private OriginsDataGenerators() {
     }
 
     public static void register(IEventBus modBus) {
-        // Data generation listeners will be attached in a future phase.
+        modBus.addListener(OriginsDataGenerators::gather);
+    }
+
+    private static void gather(GatherDataEvent event) {
+        var generator = event.getGenerator();
+
+        if (event.includeClient()) {
+            generator.addProvider(true, new OriginsEnglishLanguageProvider(generator.getPackOutput()));
+        }
     }
 }

--- a/src/main/java/io/github/origins/datagen/OriginsEnglishLanguageProvider.java
+++ b/src/main/java/io/github/origins/datagen/OriginsEnglishLanguageProvider.java
@@ -1,0 +1,20 @@
+package io.github.origins.datagen;
+
+import io.github.origins.Origins;
+import io.github.origins.registry.ModBlocks;
+import io.github.origins.registry.ModItems;
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.common.data.LanguageProvider;
+
+final class OriginsEnglishLanguageProvider extends LanguageProvider {
+    OriginsEnglishLanguageProvider(PackOutput output) {
+        super(output, Origins.MOD_ID, "en_us");
+    }
+
+    @Override
+    protected void addTranslations() {
+        addItem(ModItems.ORB_OF_ORIGIN, "Orb of Origin");
+        add(ModBlocks.ORIGIN_STONE.get(), "Origin Stone");
+        add("commands.origins.reload_soon", "Origins reload is coming soon");
+    }
+}

--- a/src/main/java/io/github/origins/network/SyncPlayerOriginPayload.java
+++ b/src/main/java/io/github/origins/network/SyncPlayerOriginPayload.java
@@ -1,0 +1,29 @@
+package io.github.origins.network;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.network.NetworkEvent;
+
+public record SyncPlayerOriginPayload(UUID playerId, ResourceLocation originId) {
+    public static void encode(SyncPlayerOriginPayload payload, FriendlyByteBuf buffer) {
+        buffer.writeUUID(payload.playerId());
+        buffer.writeResourceLocation(payload.originId());
+    }
+
+    public static SyncPlayerOriginPayload decode(FriendlyByteBuf buffer) {
+        UUID playerId = buffer.readUUID();
+        ResourceLocation originId = buffer.readResourceLocation();
+        return new SyncPlayerOriginPayload(playerId, originId);
+    }
+
+    public static void handle(SyncPlayerOriginPayload payload, Supplier<NetworkEvent.Context> contextSupplier) {
+        NetworkEvent.Context context = contextSupplier.get();
+        context.enqueueWork(() -> {
+            // Client-side handling will be implemented once power syncing is available.
+        });
+        context.setPacketHandled(true);
+    }
+}

--- a/src/main/java/io/github/origins/registry/ModBlocks.java
+++ b/src/main/java/io/github/origins/registry/ModBlocks.java
@@ -3,10 +3,17 @@ package io.github.origins.registry;
 import io.github.origins.Origins;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.RegistryObject;
 
 public final class ModBlocks {
     public static final DeferredRegister<Block> REGISTRY = DeferredRegister.create(Registries.BLOCK, Origins.MOD_ID);
+    public static final RegistryObject<Block> ORIGIN_STONE = REGISTRY.register(
+        "origin_stone",
+        () -> new Block(BlockBehaviour.Properties.ofFullCopy(Blocks.STONE))
+    );
 
     private ModBlocks() {
     }

--- a/src/main/java/io/github/origins/registry/ModItems.java
+++ b/src/main/java/io/github/origins/registry/ModItems.java
@@ -3,10 +3,20 @@ package io.github.origins.registry;
 import io.github.origins.Origins;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.BlockItem;
 import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.RegistryObject;
 
 public final class ModItems {
     public static final DeferredRegister<Item> REGISTRY = DeferredRegister.create(Registries.ITEM, Origins.MOD_ID);
+    public static final RegistryObject<Item> ORB_OF_ORIGIN = REGISTRY.register(
+        "orb_of_origin",
+        () -> new Item(new Item.Properties())
+    );
+    public static final RegistryObject<Item> ORIGIN_STONE = REGISTRY.register(
+        "origin_stone",
+        () -> new BlockItem(ModBlocks.ORIGIN_STONE.get(), new Item.Properties())
+    );
 
     private ModItems() {
     }


### PR DESCRIPTION
## Summary
- register a placeholder Origin Stone block and Orb of Origin item through the NeoForge deferred registries
- add a common configuration spec with networking/gameplay options and hook it into the mod lifecycle
- stand up initial networking/channel plumbing, a command skeleton, and client language datagen provider

## Testing
- `./gradlew compileJava` *(fails: NeoForge userdev plugin is unavailable in this execution environment so the `minecraft {}` block cannot be evaluated)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf3806f6c832780972a00facdde58