### PR TITLE
Wire Origins NeoForge bootstrap and registries

### DIFF
--- a/src/main/java/io/github/apace100/origins/common/commands/ModCommands.java
+++ b/src/main/java/io/github/apace100/origins/common/commands/ModCommands.java
@@ -5,16 +5,15 @@ import io.github.apace100.origins.Origins;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
-import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 
-public final class OriginsCommands {
-    private OriginsCommands() {
+public final class ModCommands {
+    private ModCommands() {
     }
 
-    public static void register(IEventBus modBus) {
-        NeoForge.EVENT_BUS.addListener(OriginsCommands::onRegisterCommands);
+    public static void register() {
+        NeoForge.EVENT_BUS.addListener(ModCommands::onRegisterCommands);
     }
 
     private static void onRegisterCommands(RegisterCommandsEvent event) {

--- a/src/main/java/io/github/apace100/origins/common/config/ModConfigs.java
+++ b/src/main/java/io/github/apace100/origins/common/config/ModConfigs.java
@@ -8,7 +8,7 @@ import net.neoforged.fml.config.ModConfig;
 import net.neoforged.neoforge.common.ModConfigSpec;
 import net.neoforged.neoforge.event.ModConfigEvent;
 
-public final class OriginsConfig {
+public final class ModConfigs {
     public static final ModConfigSpec SPEC;
     public static final Common COMMON;
 
@@ -18,12 +18,12 @@ public final class OriginsConfig {
         SPEC = builder.build();
     }
 
-    private OriginsConfig() {
+    private ModConfigs() {
     }
 
     public static void register(ModLoadingContext context, IEventBus modBus) {
         context.registerConfig(ModConfig.Type.COMMON, SPEC, Origins.MOD_ID + "-common.toml");
-        modBus.addListener(OriginsConfig::onConfigReloaded);
+        modBus.addListener(ModConfigs::onConfigReloaded);
     }
 
     private static void onConfigReloaded(ModConfigEvent event) {

--- a/src/main/java/io/github/apace100/origins/common/network/ModNetworking.java
+++ b/src/main/java/io/github/apace100/origins/common/network/ModNetworking.java
@@ -3,11 +3,12 @@ package io.github.apace100.origins.common.network;
 import io.github.apace100.origins.Origins;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.neoforge.network.NetworkDirection;
 import net.neoforged.neoforge.network.NetworkRegistry;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.simple.SimpleChannel;
 
-public final class Network {
+public final class ModNetworking {
     private static final String PROTOCOL_VERSION = "1";
     public static final SimpleChannel CHANNEL = NetworkRegistry.ChannelBuilder
         .named(new ResourceLocation(Origins.MOD_ID, "main"))
@@ -19,21 +20,19 @@ public final class Network {
     private static boolean bootstrapped;
     private static int index;
 
-    private Network() {
+    private ModNetworking() {
     }
 
-    public static void init() {
+    public static void register() {
         if (bootstrapped) {
             return;
         }
 
-        CHANNEL.registerMessage(
-            nextIndex(),
-            SyncConfigS2C.class,
-            SyncConfigS2C::encode,
-            SyncConfigS2C::decode,
-            SyncConfigS2C::handle
-        );
+        CHANNEL.messageBuilder(SyncConfigS2C.class, nextIndex(), NetworkDirection.PLAY_TO_CLIENT)
+            .encoder(SyncConfigS2C::encode)
+            .decoder(SyncConfigS2C::decode)
+            .consumerMainThread(SyncConfigS2C::handle)
+            .add();
 
         bootstrapped = true;
     }

--- a/src/main/java/io/github/apace100/origins/common/network/SyncConfigS2C.java
+++ b/src/main/java/io/github/apace100/origins/common/network/SyncConfigS2C.java
@@ -1,6 +1,6 @@
 package io.github.apace100.origins.common.network;
 
-import io.github.apace100.origins.common.config.OriginsConfig;
+import io.github.apace100.origins.common.config.ModConfigs;
 import java.util.function.Supplier;
 import net.minecraft.network.FriendlyByteBuf;
 import net.neoforged.neoforge.network.NetworkEvent;
@@ -21,7 +21,7 @@ public record SyncConfigS2C(boolean syncPowersOnLogin, int maxTrackedPowers) {
         NetworkEvent.Context context = contextSupplier.get();
         context.enqueueWork(() -> {
             if (context.getDirection() != null && context.getDirection().getReceptionSide().isClient()) {
-                OriginsConfig.applySync(payload);
+                ModConfigs.applySync(payload);
             }
         });
         context.setPacketHandled(true);

--- a/src/main/java/io/github/apace100/origins/common/registry/ModActions.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/ModActions.java
@@ -1,0 +1,37 @@
+package io.github.apace100.origins.common.registry;
+
+import com.mojang.serialization.Codec;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.api.Action;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+public final class ModActions {
+    public static final ResourceLocation REGISTRY_NAME = new ResourceLocation(Origins.MOD_ID, "actions");
+    public static final DeferredRegister<Codec<?>> ACTIONS =
+        DeferredRegister.createSimple(Codec.class, REGISTRY_NAME);
+
+    public static final DeferredHolder<Codec<?>, Codec<NoOpAction>> NO_OP =
+        ACTIONS.register("noop", NoOpAction::codec);
+
+    private ModActions() {
+    }
+
+    public static void register(IEventBus modBus) {
+        ACTIONS.register(modBus);
+    }
+
+    public record NoOpAction() implements Action<Void> {
+        private static final Codec<NoOpAction> CODEC = Codec.unit(new NoOpAction());
+
+        public static Codec<NoOpAction> codec() {
+            return CODEC;
+        }
+
+        @Override
+        public void run(Void context) {
+        }
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/registry/ModBlocks.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/ModBlocks.java
@@ -9,10 +9,10 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 public final class ModBlocks {
-    public static final DeferredRegister<Block> REGISTER =
+    public static final DeferredRegister<Block> BLOCKS =
         DeferredRegister.create(Registries.BLOCK, Origins.MOD_ID);
 
-    public static final DeferredHolder<Block, Block> ORIGIN_STONE = REGISTER.register(
+    public static final DeferredHolder<Block, Block> ORIGIN_STONE = BLOCKS.register(
         "origin_stone",
         () -> new Block(BlockBehaviour.Properties.ofFullCopy(Blocks.STONE))
     );

--- a/src/main/java/io/github/apace100/origins/common/registry/ModConditions.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/ModConditions.java
@@ -1,0 +1,38 @@
+package io.github.apace100.origins.common.registry;
+
+import com.mojang.serialization.Codec;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.api.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+public final class ModConditions {
+    public static final ResourceLocation REGISTRY_NAME = new ResourceLocation(Origins.MOD_ID, "conditions");
+    public static final DeferredRegister<Codec<?>> CONDITIONS =
+        DeferredRegister.createSimple(Codec.class, REGISTRY_NAME);
+
+    public static final DeferredHolder<Codec<?>, Codec<AlwaysTrueCondition>> ALWAYS_TRUE =
+        CONDITIONS.register("always_true", AlwaysTrueCondition::codec);
+
+    private ModConditions() {
+    }
+
+    public static void register(IEventBus modBus) {
+        CONDITIONS.register(modBus);
+    }
+
+    public record AlwaysTrueCondition() implements Condition<Void> {
+        private static final Codec<AlwaysTrueCondition> CODEC = Codec.unit(new AlwaysTrueCondition());
+
+        public static Codec<AlwaysTrueCondition> codec() {
+            return CODEC;
+        }
+
+        @Override
+        public boolean test(Void context) {
+            return true;
+        }
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/registry/ModItems.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/ModItems.java
@@ -9,15 +9,15 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 public final class ModItems {
-    public static final DeferredRegister<Item> REGISTER =
+    public static final DeferredRegister<Item> ITEMS =
         DeferredRegister.create(Registries.ITEM, Origins.MOD_ID);
 
-    public static final DeferredHolder<Item, Item> ORIGIN_STONE_ITEM = REGISTER.register(
+    public static final DeferredHolder<Item, Item> ORIGIN_STONE_ITEM = ITEMS.register(
         "origin_stone",
         () -> new BlockItem(ModBlocks.ORIGIN_STONE.get(), new Item.Properties())
     );
 
-    public static final DeferredHolder<Item, Item> ORB_OF_ORIGIN = REGISTER.register(
+    public static final DeferredHolder<Item, Item> ORB_OF_ORIGIN = ITEMS.register(
         "orb_of_origin",
         () -> new Item(new Item.Properties().stacksTo(1).rarity(Rarity.UNCOMMON))
     );

--- a/src/main/java/io/github/apace100/origins/common/registry/ModPowers.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/ModPowers.java
@@ -1,0 +1,32 @@
+package io.github.apace100.origins.common.registry;
+
+import com.mojang.serialization.Codec;
+import io.github.apace100.origins.Origins;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+public final class ModPowers {
+    public static final ResourceLocation REGISTRY_NAME = new ResourceLocation(Origins.MOD_ID, "powers");
+    public static final DeferredRegister<Codec<?>> POWERS =
+        DeferredRegister.createSimple(Codec.class, REGISTRY_NAME);
+
+    public static final DeferredHolder<Codec<?>, Codec<PlaceholderPower>> PLACEHOLDER =
+        POWERS.register("placeholder", PlaceholderPower::codec);
+
+    private ModPowers() {
+    }
+
+    public static void register(IEventBus modBus) {
+        POWERS.register(modBus);
+    }
+
+    public record PlaceholderPower() {
+        private static final Codec<PlaceholderPower> CODEC = Codec.unit(new PlaceholderPower());
+
+        public static Codec<PlaceholderPower> codec() {
+            return CODEC;
+        }
+    }
+}

--- a/src/main/java/io/github/apace100/origins/datagen/ModDataGen.java
+++ b/src/main/java/io/github/apace100/origins/datagen/ModDataGen.java
@@ -3,12 +3,12 @@ package io.github.apace100.origins.datagen;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 
-public final class OriginsDataGeneration {
-    private OriginsDataGeneration() {
+public final class ModDataGen {
+    private ModDataGen() {
     }
 
     public static void register(IEventBus modBus) {
-        modBus.addListener(OriginsDataGeneration::gatherData);
+        modBus.addListener(ModDataGen::gatherData);
     }
 
     private static void gatherData(GatherDataEvent event) {

--- a/src/main/java/io/github/apace100/origins/neoforge/OriginsNeoForge.java
+++ b/src/main/java/io/github/apace100/origins/neoforge/OriginsNeoForge.java
@@ -1,31 +1,33 @@
 package io.github.apace100.origins.neoforge;
 
 import io.github.apace100.origins.Origins;
-import io.github.apace100.origins.common.commands.OriginsCommands;
-import io.github.apace100.origins.common.config.OriginsConfig;
-import io.github.apace100.origins.common.network.Network;
+import io.github.apace100.origins.common.commands.ModCommands;
+import io.github.apace100.origins.common.config.ModConfigs;
+import io.github.apace100.origins.common.network.ModNetworking;
+import io.github.apace100.origins.common.registry.ModActions;
 import io.github.apace100.origins.common.registry.ModBlocks;
+import io.github.apace100.origins.common.registry.ModConditions;
 import io.github.apace100.origins.common.registry.ModItems;
-import io.github.apace100.origins.datagen.OriginsDataGeneration;
+import io.github.apace100.origins.common.registry.ModPowers;
+import io.github.apace100.origins.datagen.ModDataGen;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModLoadingContext;
 import net.neoforged.fml.common.Mod;
-import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 
 @Mod(Origins.MOD_ID)
 public final class OriginsNeoForge {
+    public static final String MODID = Origins.MOD_ID;
+
     public OriginsNeoForge(IEventBus modEventBus) {
-        ModBlocks.REGISTER.register(modEventBus);
-        ModItems.REGISTER.register(modEventBus);
+        ModBlocks.BLOCKS.register(modEventBus);
+        ModItems.ITEMS.register(modEventBus);
+        ModPowers.register(modEventBus);
+        ModActions.register(modEventBus);
+        ModConditions.register(modEventBus);
 
-        OriginsConfig.register(ModLoadingContext.get(), modEventBus);
-        OriginsCommands.register(modEventBus);
-        OriginsDataGeneration.register(modEventBus);
-
-        modEventBus.addListener(this::onCommonSetup);
-    }
-
-    private void onCommonSetup(final FMLCommonSetupEvent event) {
-        event.enqueueWork(Network::init);
+        ModConfigs.register(ModLoadingContext.get(), modEventBus);
+        ModNetworking.register();
+        ModCommands.register();
+        ModDataGen.register(modEventBus);
     }
 }

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -7,9 +7,9 @@ issueTrackerURL="https://github.com/apace100/origins/issues"
 modId="origins"
 version="${mod_version}"
 displayName="Origins (NeoForge)"
-authors="Apace100"
+authors="Apace100, Contributors"
 description='''
-Port of the Origins mod to NeoForge 1.21.1
+Origins mod ported to NeoForge.
 '''
 
 [[dependencies.origins]]


### PR DESCRIPTION
## Summary
- register blocks, items, and new codec-driven registries from the OriginsNeoForge constructor alongside config, networking, commands, and data generation wiring
- add scaffolding DeferredRegisters for powers, actions, and conditions while updating the legacy block/item registers and networking helpers to Mod* classes
- refresh NeoForge metadata to reflect the new port naming

## Testing
- ./gradlew build *(fails: Gradle userdev is not yet configured to expose the `minecraft` block in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbff07c1f08327ba4de8dca2dc343f