### PR TITLE
Refactor networking to NeoForge payload API

### DIFF
--- a/src/main/java/io/github/apace100/origins/common/network/ModNetworking.java
+++ b/src/main/java/io/github/apace100/origins/common/network/ModNetworking.java
@@ -1,51 +1,32 @@
 package io.github.apace100.origins.common.network;
 
-import io.github.apace100.origins.Origins;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.level.ServerPlayer;
-import net.neoforged.neoforge.network.NetworkDirection;
-import net.neoforged.neoforge.network.NetworkRegistry;
+import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.network.PacketDistributor;
-import net.neoforged.neoforge.network.simple.SimpleChannel;
+import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
+import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 
 public final class ModNetworking {
     private static final String PROTOCOL_VERSION = "1";
-    public static final SimpleChannel CHANNEL = NetworkRegistry.ChannelBuilder
-        .named(new ResourceLocation(Origins.MOD_ID, "main"))
-        .networkProtocolVersion(() -> PROTOCOL_VERSION)
-        .clientAcceptedVersions(PROTOCOL_VERSION::equals)
-        .serverAcceptedVersions(PROTOCOL_VERSION::equals)
-        .simpleChannel();
-
-    private static boolean bootstrapped;
-    private static int index;
 
     private ModNetworking() {
     }
 
-    public static void register() {
-        if (bootstrapped) {
-            return;
-        }
-
-        CHANNEL.messageBuilder(SyncConfigS2C.class, nextIndex(), NetworkDirection.PLAY_TO_CLIENT)
-            .encoder(SyncConfigS2C::encode)
-            .decoder(SyncConfigS2C::decode)
-            .consumerMainThread(SyncConfigS2C::handle)
-            .add();
-
-        bootstrapped = true;
+    public static void register(IEventBus modBus) {
+        modBus.addListener(ModNetworking::onRegisterPayloadHandlers);
     }
 
-    private static int nextIndex() {
-        return index++;
+    private static void onRegisterPayloadHandlers(RegisterPayloadHandlersEvent event) {
+        PayloadRegistrar registrar = event.registrar(PROTOCOL_VERSION);
+        registrar.playToClient(SyncConfigS2C.TYPE, SyncConfigS2C.STREAM_CODEC, SyncConfigS2C::handle);
     }
 
-    public static void sendToPlayer(ServerPlayer player, Object payload) {
-        CHANNEL.send(PacketDistributor.PLAYER.with(() -> player), payload);
+    public static void sendToPlayer(ServerPlayer player, CustomPacketPayload payload) {
+        PacketDistributor.sendToPlayer(player, payload);
     }
 
-    public static void sendToServer(Object payload) {
-        CHANNEL.sendToServer(payload);
+    public static void sendToServer(CustomPacketPayload payload) {
+        PacketDistributor.sendToServer(payload);
     }
 }

--- a/src/main/java/io/github/apace100/origins/common/network/SyncConfigS2C.java
+++ b/src/main/java/io/github/apace100/origins/common/network/SyncConfigS2C.java
@@ -1,29 +1,28 @@
 package io.github.apace100.origins.common.network;
 
+import io.github.apace100.origins.Origins;
 import io.github.apace100.origins.common.config.ModConfigs;
-import java.util.function.Supplier;
-import net.minecraft.network.FriendlyByteBuf;
-import net.neoforged.neoforge.network.NetworkEvent;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
 
-public record SyncConfigS2C(boolean syncPowersOnLogin, int maxTrackedPowers) {
-    public static void encode(SyncConfigS2C payload, FriendlyByteBuf buffer) {
-        buffer.writeBoolean(payload.syncPowersOnLogin());
-        buffer.writeVarInt(payload.maxTrackedPowers());
+public record SyncConfigS2C(boolean syncPowersOnLogin, int maxTrackedPowers) implements CustomPacketPayload {
+    public static final Type<SyncConfigS2C> TYPE = new Type<>(new ResourceLocation(Origins.MOD_ID, "sync_config"));
+    public static final StreamCodec<RegistryFriendlyByteBuf, SyncConfigS2C> STREAM_CODEC = StreamCodec.composite(
+        ByteBufCodecs.BOOL, SyncConfigS2C::syncPowersOnLogin,
+        ByteBufCodecs.VAR_INT, SyncConfigS2C::maxTrackedPowers,
+        SyncConfigS2C::new
+    );
+
+    @Override
+    public Type<SyncConfigS2C> type() {
+        return TYPE;
     }
 
-    public static SyncConfigS2C decode(FriendlyByteBuf buffer) {
-        boolean syncPowersOnLogin = buffer.readBoolean();
-        int maxTrackedPowers = buffer.readVarInt();
-        return new SyncConfigS2C(syncPowersOnLogin, maxTrackedPowers);
-    }
-
-    public static void handle(SyncConfigS2C payload, Supplier<NetworkEvent.Context> contextSupplier) {
-        NetworkEvent.Context context = contextSupplier.get();
-        context.enqueueWork(() -> {
-            if (context.getDirection() != null && context.getDirection().getReceptionSide().isClient()) {
-                ModConfigs.applySync(payload);
-            }
-        });
-        context.setPacketHandled(true);
+    public static void handle(SyncConfigS2C payload, IPayloadContext context) {
+        context.enqueueWork(() -> ModConfigs.applySync(payload));
     }
 }

--- a/src/main/java/io/github/apace100/origins/neoforge/OriginsNeoForge.java
+++ b/src/main/java/io/github/apace100/origins/neoforge/OriginsNeoForge.java
@@ -26,7 +26,7 @@ public final class OriginsNeoForge {
         ModConditions.register(modEventBus);
 
         ModConfigs.register(ModLoadingContext.get(), modEventBus);
-        ModNetworking.register();
+        ModNetworking.register(modEventBus);
         ModCommands.register();
         ModDataGen.register(modEventBus);
     }


### PR DESCRIPTION
## Summary
- replace the simple channel bootstrap with NeoForge's payload registrar
- convert the sync config packet to a CustomPacketPayload with a stream codec
- hook networking registration into the mod event bus entrypoint

## Testing
- not run (NeoForge userdev not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dc06315c6083278090307473794a12