### PR TITLE
Broadcast config sync payload when players join

### DIFF
--- a/src/main/java/io/github/apace100/origins/common/config/ModConfigs.java
+++ b/src/main/java/io/github/apace100/origins/common/config/ModConfigs.java
@@ -36,6 +36,13 @@ public final class ModConfigs {
         COMMON.applySync(payload);
     }
 
+    public static SyncConfigS2C createSyncPayload() {
+        return new SyncConfigS2C(
+            COMMON.syncPowersOnLogin.get(),
+            COMMON.maxTrackedPowers.get()
+        );
+    }
+
     public static final class Common {
         public final ModConfigSpec.BooleanValue syncPowersOnLogin;
         public final ModConfigSpec.IntValue maxTrackedPowers;

--- a/src/main/java/io/github/apace100/origins/common/network/ModNetworking.java
+++ b/src/main/java/io/github/apace100/origins/common/network/ModNetworking.java
@@ -1,8 +1,11 @@
 package io.github.apace100.origins.common.network;
 
+import io.github.apace100.origins.common.config.ModConfigs;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
@@ -15,11 +18,20 @@ public final class ModNetworking {
 
     public static void register(IEventBus modBus) {
         modBus.addListener(ModNetworking::onRegisterPayloadHandlers);
+        NeoForge.EVENT_BUS.addListener(ModNetworking::onPlayerLoggedIn);
     }
 
     private static void onRegisterPayloadHandlers(RegisterPayloadHandlersEvent event) {
         PayloadRegistrar registrar = event.registrar(PROTOCOL_VERSION);
         registrar.playToClient(SyncConfigS2C.TYPE, SyncConfigS2C.STREAM_CODEC, SyncConfigS2C::handle);
+    }
+
+    private static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
+        if (!(event.getEntity() instanceof ServerPlayer player)) {
+            return;
+        }
+
+        sendToPlayer(player, ModConfigs.createSyncPayload());
     }
 
     public static void sendToPlayer(ServerPlayer player, CustomPacketPayload payload) {


### PR DESCRIPTION
## Summary
- add a helper to build the sync-config payload from the current server config values
- register a NeoForge player login listener that sends the config payload to joining players

## Testing
- ./gradlew build *(fails: NeoForge userdev is unavailable in this environment, so the minecraft {} block cannot be evaluated)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0c056a14832799186254778f6d68