### PR TITLE
Refactor event wiring for NeoForge

### DIFF
--- a/src/main/java/io/github/apace100/origins/common/commands/ModCommands.java
+++ b/src/main/java/io/github/apace100/origins/common/commands/ModCommands.java
@@ -5,18 +5,17 @@ import io.github.apace100.origins.Origins;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
-import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 
+@Mod.EventBusSubscriber(modid = Origins.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public final class ModCommands {
     private ModCommands() {
     }
 
-    public static void register() {
-        NeoForge.EVENT_BUS.addListener(ModCommands::onRegisterCommands);
-    }
-
-    private static void onRegisterCommands(RegisterCommandsEvent event) {
+    @SubscribeEvent
+    public static void onRegisterCommands(RegisterCommandsEvent event) {
         register(event.getDispatcher());
     }
 

--- a/src/main/java/io/github/apace100/origins/common/network/ModNetworking.java
+++ b/src/main/java/io/github/apace100/origins/common/network/ModNetworking.java
@@ -1,17 +1,20 @@
 package io.github.apace100.origins.common.network;
 
+import io.github.apace100.origins.Origins;
 import io.github.apace100.origins.common.config.ModConfigs;
 import io.github.apace100.origins.neoforge.capability.PlayerOrigin;
 import io.github.apace100.origins.neoforge.capability.PlayerOriginManager;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 
+@Mod.EventBusSubscriber(modid = Origins.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public final class ModNetworking {
     private static final String PROTOCOL_VERSION = "1";
 
@@ -20,7 +23,6 @@ public final class ModNetworking {
 
     public static void register(IEventBus modBus) {
         modBus.addListener(ModNetworking::onRegisterPayloadHandlers);
-        NeoForge.EVENT_BUS.addListener(ModNetworking::onPlayerLoggedIn);
     }
 
     private static void onRegisterPayloadHandlers(RegisterPayloadHandlersEvent event) {
@@ -29,7 +31,8 @@ public final class ModNetworking {
         registrar.playToClient(SyncOriginS2C.TYPE, SyncOriginS2C.STREAM_CODEC, SyncOriginS2C::handle);
     }
 
-    private static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
+    @SubscribeEvent
+    public static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
         if (!(event.getEntity() instanceof ServerPlayer player)) {
             return;
         }

--- a/src/main/java/io/github/apace100/origins/neoforge/OriginsNeoForge.java
+++ b/src/main/java/io/github/apace100/origins/neoforge/OriginsNeoForge.java
@@ -1,7 +1,6 @@
 package io.github.apace100.origins.neoforge;
 
 import io.github.apace100.origins.Origins;
-import io.github.apace100.origins.common.commands.ModCommands;
 import io.github.apace100.origins.common.config.ModConfigs;
 import io.github.apace100.origins.common.network.ModNetworking;
 import io.github.apace100.origins.common.registry.ModActions;
@@ -10,7 +9,6 @@ import io.github.apace100.origins.common.registry.ModConditions;
 import io.github.apace100.origins.common.registry.ModItems;
 import io.github.apace100.origins.common.registry.ModPowers;
 import io.github.apace100.origins.neoforge.capability.OriginCapabilities;
-import io.github.apace100.origins.neoforge.capability.PlayerOriginEvents;
 import io.github.apace100.origins.neoforge.capability.PlayerOriginProvider;
 import io.github.apace100.origins.datagen.ModDataGen;
 import net.minecraft.world.entity.EntityType;
@@ -32,12 +30,10 @@ public final class OriginsNeoForge {
 
         ModConfigs.register(ModLoadingContext.get(), modEventBus);
         ModNetworking.register(modEventBus);
-        ModCommands.register();
         ModDataGen.register(modEventBus);
 
         modEventBus.addListener(this::registerCapabilities);
 
-        PlayerOriginEvents.register();
     }
 
     private void registerCapabilities(RegisterCapabilitiesEvent event) {

--- a/src/main/java/io/github/apace100/origins/neoforge/capability/PlayerOriginEvents.java
+++ b/src/main/java/io/github/apace100/origins/neoforge/capability/PlayerOriginEvents.java
@@ -1,19 +1,18 @@
 package io.github.apace100.origins.neoforge.capability;
 
+import io.github.apace100.origins.Origins;
 import net.minecraft.server.level.ServerPlayer;
-import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 
+@Mod.EventBusSubscriber(modid = Origins.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public final class PlayerOriginEvents {
     private PlayerOriginEvents() {
     }
 
-    public static void register() {
-        NeoForge.EVENT_BUS.addListener(PlayerOriginEvents::onClone);
-        NeoForge.EVENT_BUS.addListener(PlayerOriginEvents::onLoggedOut);
-    }
-
-    private static void onClone(PlayerEvent.Clone event) {
+    @SubscribeEvent
+    public static void onClone(PlayerEvent.Clone event) {
         if (event.getEntity().level().isClientSide) {
             return;
         }
@@ -21,7 +20,8 @@ public final class PlayerOriginEvents {
         PlayerOriginManager.copy(event.getOriginal(), event.getEntity());
     }
 
-    private static void onLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
+    @SubscribeEvent
+    public static void onLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
         if (!(event.getEntity() instanceof ServerPlayer player)) {
             return;
         }


### PR DESCRIPTION
## Summary
- switch command registration, networking login sync, and capability clone/logout handlers to NeoForge's @Mod.EventBusSubscriber model
- remove manual NeoForge.EVENT_BUS registrations from the OriginsNeoForge entrypoint now that subscribers handle the wiring

## Testing
- ./gradlew compileJava *(fails: buildscript missing minecraft() signature in build.gradle line 22)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2f2970b08327a3e4369ea868b469