### PR TITLE
Switch build scripts to NeoForge 7 userdev layout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@ plugins {
     id 'net.neoforged.gradle.userdev' version '7.0.190'
 }
 
-group = project.findProperty('group') ?: 'io.github.apace100'
-version = (project.findProperty('mod_version') ?: '1.0.0')
-archivesBaseName = project.findProperty('archives_base_name') ?: 'origins-neoforge'
+group = 'io.github.apace100'
+version = '1.0.0'
+archivesBaseName = 'origins-neoforge'
 
 java {
     toolchain {
@@ -14,71 +14,16 @@ java {
 }
 
 repositories {
-    mavenLocal()
-    maven { url = 'https://maven.neoforged.net/releases' }
     mavenCentral()
-}
-
-minecraft {
-    // official mappings for the target MC version
-    mappings channel: 'official', version: project.minecraftVersion
-
-    runs {
-        client {
-            workingDirectory project.file('run/client')
-            property 'forge.logging.console.level', 'debug'
-        }
-        server {
-            workingDirectory project.file('run/server')
-            property 'forge.logging.console.level', 'debug'
-        }
-        data {
-            workingDirectory project.file('run/data')
-            args '--mod', 'origins', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
-        }
-    }
+    maven { url = 'https://maven.neoforged.net/releases' }
 }
 
 dependencies {
-    // NeoForge runtime
-    implementation "net.neoforged:neoforge:${project.neoForgeVersion}"
-
-    // Example utility lib
+    implementation "net.neoforged:neoforge:${neoForgeVersion}"
     implementation 'com.google.guava:guava:31.1-jre'
-}
-
-sourceSets {
-    main {
-        resources {
-            srcDir 'src/generated/resources'
-            exclude '.cache/**'
-        }
-    }
 }
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
     options.release = 21
-}
-
-processResources {
-    // Expand mod version into TOML if the placeholder is present
-    inputs.property 'version', project.version
-    filesMatching('META-INF/*.toml') {
-        expand(version: project.version, mod_version: project.version)
-    }
-}
-
-jar {
-    archiveBaseName.set(archivesBaseName)
-    manifest {
-        attributes(
-            'Specification-Title': archivesBaseName,
-            'Specification-Vendor': group,
-            'Specification-Version': project.version,
-            'Implementation-Title': archivesBaseName,
-            'Implementation-Version': project.version,
-            'Implementation-Vendor': group
-        )
-    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,7 @@
-# Versions
+# JVM tuning
+org.gradle.jvmargs=-Xmx2G -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions
+
+# NeoForge / Minecraft versions
 minecraftVersion=1.21.1
 neoForgeVersion=21.1.209
-mod_version=1.0.0
-group=io.github.apace100
-archives_base_name=origins-neoforge
-
-# Gradle/JVM
-org.gradle.jvmargs=-Xmx2G -Xms1G -Dfile.encoding=UTF-8
-org.gradle.parallel=true
-org.gradle.caching=true
-org.gradle.daemon=true
+modVersion=1.0.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,8 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven { url = "https://maven.neoforged.net/releases" }
-        mavenCentral()
+        maven { url = 'https://maven.neoforged.net/releases' }
     }
 }
+
 rootProject.name = "origins-neoforge"

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,11 +1,11 @@
-modLoader="javafml"
-loaderVersion="[1,)"
+modLoader="neoforge"
+loaderVersion="[21,)"
 license="MIT"
 issueTrackerURL="https://github.com/apace100/origins/issues"
 
 [[mods]]
 modId="origins"
-version="${mod_version}"
+version="${modVersion}"
 displayName="Origins (NeoForge)"
 authors="Apace100, Contributors"
 description='''


### PR DESCRIPTION
## Summary
- replace Gradle build, settings, and properties files with the NeoForge 7.x userdev configuration
- update neoforge.mods.toml metadata to use the neoforge loader identifier and matching version range

## Testing
- ./gradlew --refresh-dependencies clean compileJava --stacktrace --console=plain *(fails: existing sources still reference deprecated Forge/Fabric APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68dc36e03de083278120d9db3b051b44