### PR TITLE
Port registries and events to NeoForge APIs

### DIFF
--- a/src/main/java/io/github/apace100/origins/common/commands/ModCommands.java
+++ b/src/main/java/io/github/apace100/origins/common/commands/ModCommands.java
@@ -6,10 +6,10 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
 import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 
-@Mod.EventBusSubscriber(modid = Origins.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+@EventBusSubscriber(modid = Origins.MOD_ID, bus = EventBusSubscriber.Bus.GAME)
 public final class ModCommands {
     private ModCommands() {
     }

--- a/src/main/java/io/github/apace100/origins/common/config/ModConfigs.java
+++ b/src/main/java/io/github/apace100/origins/common/config/ModConfigs.java
@@ -5,8 +5,8 @@ import io.github.apace100.origins.common.network.SyncConfigS2C;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModLoadingContext;
 import net.neoforged.fml.config.ModConfig;
+import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.common.ModConfigSpec;
-import net.neoforged.neoforge.event.ModConfigEvent;
 
 public final class ModConfigs {
     public static final ModConfigSpec SPEC;
@@ -22,7 +22,7 @@ public final class ModConfigs {
     }
 
     public static void register(ModLoadingContext context, IEventBus modBus) {
-        context.registerConfig(ModConfig.Type.COMMON, SPEC, Origins.MOD_ID + "-common.toml");
+        context.getActiveContainer().registerConfig(ModConfig.Type.COMMON, SPEC, Origins.MOD_ID + "-common.toml");
         modBus.addListener(ModConfigs::onConfigReloaded);
     }
 

--- a/src/main/java/io/github/apace100/origins/common/network/ModNetworking.java
+++ b/src/main/java/io/github/apace100/origins/common/network/ModNetworking.java
@@ -8,13 +8,13 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 
-@Mod.EventBusSubscriber(modid = Origins.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+@EventBusSubscriber(modid = Origins.MOD_ID, bus = EventBusSubscriber.Bus.GAME)
 public final class ModNetworking {
     private static final String PROTOCOL_VERSION = "1";
 

--- a/src/main/java/io/github/apace100/origins/common/network/SyncConfigS2C.java
+++ b/src/main/java/io/github/apace100/origins/common/network/SyncConfigS2C.java
@@ -10,7 +10,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 
 public record SyncConfigS2C(boolean syncPowersOnLogin, int maxTrackedPowers) implements CustomPacketPayload {
-    public static final Type<SyncConfigS2C> TYPE = new Type<>(new ResourceLocation(Origins.MOD_ID, "sync_config"));
+    public static final Type<SyncConfigS2C> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "sync_config"));
     public static final StreamCodec<RegistryFriendlyByteBuf, SyncConfigS2C> STREAM_CODEC = StreamCodec.composite(
         ByteBufCodecs.BOOL, SyncConfigS2C::syncPowersOnLogin,
         ByteBufCodecs.VAR_INT, SyncConfigS2C::maxTrackedPowers,

--- a/src/main/java/io/github/apace100/origins/common/network/SyncOriginS2C.java
+++ b/src/main/java/io/github/apace100/origins/common/network/SyncOriginS2C.java
@@ -14,7 +14,7 @@ import net.neoforged.neoforge.network.handling.IPayloadContext;
 import java.util.Optional;
 
 public record SyncOriginS2C(Optional<ResourceLocation> originId) implements CustomPacketPayload {
-    public static final Type<SyncOriginS2C> TYPE = new Type<>(new ResourceLocation(Origins.MOD_ID, "sync_origin"));
+    public static final Type<SyncOriginS2C> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "sync_origin"));
     public static final StreamCodec<RegistryFriendlyByteBuf, SyncOriginS2C> STREAM_CODEC = StreamCodec.composite(
         ByteBufCodecs.optional(ResourceLocation.STREAM_CODEC), SyncOriginS2C::originId, SyncOriginS2C::new
     );

--- a/src/main/java/io/github/apace100/origins/common/registry/ModActions.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/ModActions.java
@@ -9,9 +9,9 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 public final class ModActions {
-    public static final ResourceLocation REGISTRY_NAME = new ResourceLocation(Origins.MOD_ID, "actions");
+    public static final ResourceLocation REGISTRY_NAME = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "actions");
     public static final DeferredRegister<Codec<?>> ACTIONS =
-        DeferredRegister.createSimple(Codec.class, REGISTRY_NAME);
+        DeferredRegister.create(REGISTRY_NAME, Origins.MOD_ID);
 
     public static final DeferredHolder<Codec<?>, Codec<NoOpAction>> NO_OP =
         ACTIONS.register("noop", NoOpAction::codec);

--- a/src/main/java/io/github/apace100/origins/common/registry/ModConditions.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/ModConditions.java
@@ -9,9 +9,9 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 public final class ModConditions {
-    public static final ResourceLocation REGISTRY_NAME = new ResourceLocation(Origins.MOD_ID, "conditions");
+    public static final ResourceLocation REGISTRY_NAME = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "conditions");
     public static final DeferredRegister<Codec<?>> CONDITIONS =
-        DeferredRegister.createSimple(Codec.class, REGISTRY_NAME);
+        DeferredRegister.create(REGISTRY_NAME, Origins.MOD_ID);
 
     public static final DeferredHolder<Codec<?>, Codec<AlwaysTrueCondition>> ALWAYS_TRUE =
         CONDITIONS.register("always_true", AlwaysTrueCondition::codec);

--- a/src/main/java/io/github/apace100/origins/common/registry/ModPowers.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/ModPowers.java
@@ -8,9 +8,9 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 public final class ModPowers {
-    public static final ResourceLocation REGISTRY_NAME = new ResourceLocation(Origins.MOD_ID, "powers");
+    public static final ResourceLocation REGISTRY_NAME = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "powers");
     public static final DeferredRegister<Codec<?>> POWERS =
-        DeferredRegister.createSimple(Codec.class, REGISTRY_NAME);
+        DeferredRegister.create(REGISTRY_NAME, Origins.MOD_ID);
 
     public static final DeferredHolder<Codec<?>, Codec<PlaceholderPower>> PLACEHOLDER =
         POWERS.register("placeholder", PlaceholderPower::codec);

--- a/src/main/java/io/github/apace100/origins/neoforge/capability/OriginCapabilities.java
+++ b/src/main/java/io/github/apace100/origins/neoforge/capability/OriginCapabilities.java
@@ -6,7 +6,7 @@ import net.neoforged.neoforge.capabilities.EntityCapability;
 
 public final class OriginCapabilities {
     public static final EntityCapability<PlayerOrigin, Void> PLAYER_ORIGIN = EntityCapability.createVoid(
-        new ResourceLocation(Origins.MOD_ID, "origin"), PlayerOrigin.class
+        ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "origin"), PlayerOrigin.class
     );
 
     private OriginCapabilities() {

--- a/src/main/java/io/github/apace100/origins/neoforge/capability/PlayerOriginEvents.java
+++ b/src/main/java/io/github/apace100/origins/neoforge/capability/PlayerOriginEvents.java
@@ -3,10 +3,10 @@ package io.github.apace100.origins.neoforge.capability;
 import io.github.apace100.origins.Origins;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 
-@Mod.EventBusSubscriber(modid = Origins.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+@EventBusSubscriber(modid = Origins.MOD_ID, bus = EventBusSubscriber.Bus.GAME)
 public final class PlayerOriginEvents {
     private PlayerOriginEvents() {
     }

--- a/src/main/java/io/github/apace100/origins/platform/capabilities/OriginCapabilities.java
+++ b/src/main/java/io/github/apace100/origins/platform/capabilities/OriginCapabilities.java
@@ -1,14 +1,24 @@
 package io.github.apace100.origins.platform.capabilities;
 
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EntityType;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.capabilities.EntityCapability;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 
-public class OriginCapabilities {
+public final class OriginCapabilities {
+    public static final EntityCapability<PlayerOrigin, Void> PLAYER_ORIGIN = EntityCapability.createVoid(
+        ResourceLocation.fromNamespaceAndPath("origins", "origin"),
+        PlayerOrigin.class
+    );
+
+    private OriginCapabilities() {}
+
     public static void register(IEventBus modEventBus) {
         modEventBus.addListener(OriginCapabilities::onRegisterCaps);
     }
 
     private static void onRegisterCaps(RegisterCapabilitiesEvent event) {
-        event.register(PlayerOrigin.class);
+        event.registerEntity(PLAYER_ORIGIN, EntityType.PLAYER, new PlayerOriginProvider());
     }
 }

--- a/src/main/java/io/github/apace100/origins/platform/config/ModConfig.java
+++ b/src/main/java/io/github/apace100/origins/platform/config/ModConfig.java
@@ -2,15 +2,19 @@ package io.github.apace100.origins.platform.config;
 
 import net.neoforged.neoforge.common.ModConfigSpec;
 import net.neoforged.fml.ModLoadingContext;
-import net.neoforged.fml.config.ModConfig;
 
-public class ModConfig {
+public final class ModConfig {
     public static ModConfigSpec COMMON;
+
+    private ModConfig() {}
 
     public static void register() {
         ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
         builder.comment("Origins config");
         COMMON = builder.build();
-        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, COMMON);
+        ModLoadingContext.get().getActiveContainer().registerConfig(
+            net.neoforged.fml.config.ModConfig.Type.COMMON,
+            COMMON
+        );
     }
 }

--- a/src/main/java/io/github/apace100/origins/platform/network/OriginsNetworking.java
+++ b/src/main/java/io/github/apace100/origins/platform/network/OriginsNetworking.java
@@ -2,6 +2,7 @@ package io.github.apace100.origins.platform.network;
 
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
+import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 
 public class OriginsNetworking {
 
@@ -10,6 +11,7 @@ public class OriginsNetworking {
     }
 
     private static void onRegisterPayloads(RegisterPayloadHandlersEvent event) {
-        event.registrar("1").play(SyncOriginPayload.TYPE, SyncOriginPayload.STREAM_CODEC, SyncOriginPayload::handle);
+        PayloadRegistrar registrar = event.registrar("1");
+        registrar.playToClient(SyncOriginPayload.TYPE, SyncOriginPayload.STREAM_CODEC, SyncOriginPayload::handle);
     }
 }

--- a/src/main/java/io/github/apace100/origins/platform/network/SyncOriginPayload.java
+++ b/src/main/java/io/github/apace100/origins/platform/network/SyncOriginPayload.java
@@ -10,7 +10,7 @@ import net.neoforged.neoforge.network.handling.IPayloadContext;
 
 public record SyncOriginPayload(String originId) implements CustomPacketPayload {
 
-    public static final Type<SyncOriginPayload> TYPE = new Type<>(new ResourceLocation("origins", "sync_origin"));
+    public static final Type<SyncOriginPayload> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath("origins", "sync_origin"));
     public static final StreamCodec<FriendlyByteBuf, SyncOriginPayload> STREAM_CODEC =
             StreamCodec.of((buf, payload) -> buf.writeUtf(payload.originId),
                            buf -> new SyncOriginPayload(buf.readUtf()));

--- a/src/main/java/io/github/apace100/origins/platform/registry/ModBlocks.java
+++ b/src/main/java/io/github/apace100/origins/platform/registry/ModBlocks.java
@@ -1,14 +1,17 @@
 package io.github.apace100.origins.platform.registry;
 
+import net.minecraft.core.registries.Registries;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
-import net.neoforged.neoforge.registries.RegistryObject;
-import net.minecraft.core.registries.Registries;
 
 public class ModBlocks {
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(Registries.BLOCK, "origins");
 
-    public static final RegistryObject<Block> ORIGIN_STONE = BLOCKS.register("origin_stone",
-            () -> new Block(Block.Properties.copy(Blocks.STONE)));
+    public static final DeferredHolder<Block, Block> ORIGIN_STONE = BLOCKS.register(
+        "origin_stone",
+        () -> new Block(BlockBehaviour.Properties.ofFullCopy(Blocks.STONE))
+    );
 }

--- a/src/main/java/io/github/apace100/origins/platform/registry/ModItems.java
+++ b/src/main/java/io/github/apace100/origins/platform/registry/ModItems.java
@@ -1,14 +1,15 @@
 package io.github.apace100.origins.platform.registry;
 
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.BlockItem;
-import net.neoforged.neoforge.registries.DeferredRegister;
-import net.neoforged.neoforge.registries.RegistryObject;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.world.item.Item;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
 
 public class ModItems {
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(Registries.ITEM, "origins");
 
-    public static final RegistryObject<Item> ORB_OF_ORIGIN = ITEMS.register("orb_of_origin",
-            () -> new Item(new Item.Properties()));
+    public static final DeferredHolder<Item, Item> ORB_OF_ORIGIN = ITEMS.register(
+        "orb_of_origin",
+        () -> new Item(new Item.Properties())
+    );
 }


### PR DESCRIPTION
## Summary
- migrate item, block, power, action, and condition registrations to DeferredRegister/DeferredHolder patterns compatible with NeoForge 21.1
- switch command, networking, and capability event listeners over to NeoForge's @EventBusSubscriber and payload registrar APIs
- refresh platform scaffolding to use the capability provider model and updated config registration hooks

## Testing
- `./gradlew compileJava --stacktrace --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68dc394b51088327ac45c04e65c781da