### PR TITLE
Set up Origins mod for NeoForge 1.21.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,9 @@ plugins {
     id 'net.neoforged.gradle.userdev' version '7.0.190'
 }
 
-group = 'io.github.apace100'
-version = modVersion
-
-base {
-    archivesName = 'origins-neoforge'
-}
+group = project.modGroup
+version = project.modVersion
+archivesBaseName = 'origins-neoforge'
 
 java {
     toolchain {
@@ -17,23 +14,24 @@ java {
 }
 
 repositories {
-    mavenCentral()
+    mavenLocal()
     maven { url = 'https://maven.neoforged.net/releases' }
+    mavenCentral()
 }
 
 dependencies {
-    implementation "net.neoforged:neoforge:${neoForgeVersion}"
+    implementation "net.neoforged:neoforge:${project.neoForgeVersion}"
     implementation 'com.google.guava:guava:31.1-jre'
 }
 
-tasks.withType(JavaCompile).configureEach {
-    options.encoding = 'UTF-8'
-    options.release = 21
-}
-
-tasks.named('processResources', ProcessResources).configure {
-    inputs.property 'modVersion', modVersion
-    filesMatching('META-INF/neoforge.mods.toml') {
-        expand(modVersion: modVersion)
+processResources {
+    def props = [
+        version         : project.version,
+        neoForgeVersion : project.neoForgeVersion,
+        minecraftVersion: project.minecraftVersion
+    ]
+    inputs.properties(props)
+    filesMatching("META-INF/neoforge.mods.toml") {
+        expand(props)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,8 @@
-# JVM tuning
-org.gradle.jvmargs=-Xmx2G -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions
+org.gradle.jvmargs=-Xmx2G -XX:+UseG1GC -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
 
-# NeoForge / Minecraft versions
 minecraftVersion=1.21.1
 neoForgeVersion=21.1.209
 modVersion=1.0.0
+modGroup=io.github.apace100.origins

--- a/src/main/java/io/github/apace100/origins/capability/OriginCapabilities.java
+++ b/src/main/java/io/github/apace100/origins/capability/OriginCapabilities.java
@@ -1,0 +1,22 @@
+package io.github.apace100.origins.capability;
+
+import io.github.apace100.origins.util.OriginsConstants;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EntityType;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.capabilities.EntityCapability;
+import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+
+@EventBusSubscriber(modid = OriginsConstants.MODID, bus = EventBusSubscriber.Bus.MOD)
+public final class OriginCapabilities {
+    public static final EntityCapability<PlayerOrigin, Void> PLAYER_ORIGIN = EntityCapability.createVoid(ResourceLocation.fromNamespaceAndPath(OriginsConstants.MODID, "player_origin"), PlayerOrigin.class);
+
+    private OriginCapabilities() {
+    }
+
+    @SubscribeEvent
+    public static void registerCapabilities(RegisterCapabilitiesEvent event) {
+        event.registerEntity(PLAYER_ORIGIN, EntityType.PLAYER, (player, context) -> PlayerOriginProvider.get(player));
+    }
+}

--- a/src/main/java/io/github/apace100/origins/capability/PlayerOrigin.java
+++ b/src/main/java/io/github/apace100/origins/capability/PlayerOrigin.java
@@ -1,0 +1,34 @@
+package io.github.apace100.origins.capability;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Optional;
+
+public class PlayerOrigin {
+    private ResourceLocation originId;
+
+    public Optional<ResourceLocation> getOriginId() {
+        return Optional.ofNullable(originId);
+    }
+
+    public void setOriginId(ResourceLocation originId) {
+        this.originId = originId;
+    }
+
+    public CompoundTag save() {
+        CompoundTag tag = new CompoundTag();
+        if (originId != null) {
+            tag.putString("Origin", originId.toString());
+        }
+        return tag;
+    }
+
+    public void load(CompoundTag tag) {
+        if (tag.contains("Origin")) {
+            originId = ResourceLocation.tryParse(tag.getString("Origin"));
+        } else {
+            originId = null;
+        }
+    }
+}

--- a/src/main/java/io/github/apace100/origins/capability/PlayerOriginProvider.java
+++ b/src/main/java/io/github/apace100/origins/capability/PlayerOriginProvider.java
@@ -1,0 +1,38 @@
+package io.github.apace100.origins.capability;
+
+import io.github.apace100.origins.util.OriginsConstants;
+import net.minecraft.world.entity.player.Player;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@EventBusSubscriber(modid = OriginsConstants.MODID, bus = EventBusSubscriber.Bus.GAME)
+public final class PlayerOriginProvider {
+    private static final Map<UUID, PlayerOrigin> ORIGINS = new ConcurrentHashMap<>();
+
+    private PlayerOriginProvider() {
+    }
+
+    public static PlayerOrigin get(Player player) {
+        return ORIGINS.computeIfAbsent(player.getUUID(), id -> new PlayerOrigin());
+    }
+
+    @SubscribeEvent
+    public static void clone(PlayerEvent.Clone event) {
+        if (!event.isWasDeath()) {
+            return;
+        }
+        PlayerOrigin original = get(event.getOriginal());
+        PlayerOrigin copy = get(event.getEntity());
+        copy.setOriginId(original.getOriginId().orElse(null));
+    }
+
+    @SubscribeEvent
+    public static void logout(PlayerEvent.PlayerLoggedOutEvent event) {
+        ORIGINS.remove(event.getEntity().getUUID());
+    }
+}

--- a/src/main/java/io/github/apace100/origins/command/OriginsCommands.java
+++ b/src/main/java/io/github/apace100/origins/command/OriginsCommands.java
@@ -1,0 +1,21 @@
+package io.github.apace100.origins.command;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import io.github.apace100.origins.util.OriginsConstants;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
+
+@EventBusSubscriber(modid = OriginsConstants.MODID, bus = EventBusSubscriber.Bus.GAME)
+public final class OriginsCommands {
+    private OriginsCommands() {
+    }
+
+    @SubscribeEvent
+    public static void register(RegisterCommandsEvent event) {
+        LiteralArgumentBuilder<CommandSourceStack> root = Commands.literal("origins").executes(ctx -> 0);
+        event.getDispatcher().register(root);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/config/OriginsConfig.java
+++ b/src/main/java/io/github/apace100/origins/config/OriginsConfig.java
@@ -1,0 +1,27 @@
+package io.github.apace100.origins.config;
+
+import io.github.apace100.origins.util.OriginsConstants;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.fml.event.config.ModConfigEvent;
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+@EventBusSubscriber(modid = OriginsConstants.MODID)
+public final class OriginsConfig {
+    public static final ModConfigSpec COMMON_SPEC;
+    public static final ModConfigSpec.BooleanValue ENABLE_ORB_OF_ORIGIN;
+
+    static {
+        ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
+        ENABLE_ORB_OF_ORIGIN = builder.comment("Allows the Orb of Origin item to function.").define("enableOrbOfOrigin", true);
+        COMMON_SPEC = builder.build();
+    }
+
+    private OriginsConfig() {
+    }
+
+    @SubscribeEvent
+    public static void onLoad(ModConfigEvent event) {
+        // Placeholder for config sync hooks
+    }
+}

--- a/src/main/java/io/github/apace100/origins/datagen/OriginsDataGen.java
+++ b/src/main/java/io/github/apace100/origins/datagen/OriginsDataGen.java
@@ -1,0 +1,35 @@
+package io.github.apace100.origins.datagen;
+
+import io.github.apace100.origins.datagen.provider.OriginsBlockStateProvider;
+import io.github.apace100.origins.datagen.provider.OriginsBlockTags;
+import io.github.apace100.origins.datagen.provider.OriginsItemModelProvider;
+import io.github.apace100.origins.datagen.provider.OriginsItemTags;
+import io.github.apace100.origins.datagen.provider.OriginsLanguageProvider;
+import io.github.apace100.origins.datagen.provider.OriginsLootTableProvider;
+import io.github.apace100.origins.datagen.provider.OriginsRecipeProvider;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.data.event.GatherDataEvent;
+
+@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
+public final class OriginsDataGen {
+    private OriginsDataGen() {
+    }
+
+    @SubscribeEvent
+    public static void gatherData(GatherDataEvent event) {
+        var generator = event.getGenerator();
+        var pack = generator.getPackOutput();
+        var lookup = event.getLookupProvider();
+        var existing = event.getExistingFileHelper();
+
+        generator.addProvider(event.includeClient(), new OriginsLanguageProvider(pack));
+        generator.addProvider(event.includeClient(), new OriginsBlockStateProvider(pack, existing));
+        generator.addProvider(event.includeClient(), new OriginsItemModelProvider(pack, existing));
+        generator.addProvider(event.includeServer(), new OriginsLootTableProvider(pack, lookup));
+        generator.addProvider(event.includeServer(), new OriginsRecipeProvider(pack, lookup));
+        var blockTags = new OriginsBlockTags(pack, lookup, existing);
+        generator.addProvider(event.includeServer(), blockTags);
+        generator.addProvider(event.includeServer(), new OriginsItemTags(pack, lookup, blockTags.contentsGetter(), existing));
+    }
+}

--- a/src/main/java/io/github/apace100/origins/datagen/provider/OriginsBlockLootTables.java
+++ b/src/main/java/io/github/apace100/origins/datagen/provider/OriginsBlockLootTables.java
@@ -1,0 +1,27 @@
+package io.github.apace100.origins.datagen.provider;
+
+import io.github.apace100.origins.registry.OriginsBlocks;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.world.flag.FeatureFlags;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.data.loot.BlockLootSubProvider;
+
+import java.util.List;
+import java.util.Set;
+
+public class OriginsBlockLootTables extends BlockLootSubProvider {
+    public OriginsBlockLootTables(HolderLookup.Provider lookup) {
+        super(Set.<Item>of(), FeatureFlags.REGISTRY.allFlags(), lookup);
+    }
+
+    @Override
+    protected void generate() {
+        dropSelf(OriginsBlocks.ORIGIN_STONE.get());
+    }
+
+    @Override
+    protected Iterable<Block> getKnownBlocks() {
+        return List.of(OriginsBlocks.ORIGIN_STONE.get());
+    }
+}

--- a/src/main/java/io/github/apace100/origins/datagen/provider/OriginsBlockStateProvider.java
+++ b/src/main/java/io/github/apace100/origins/datagen/provider/OriginsBlockStateProvider.java
@@ -1,0 +1,18 @@
+package io.github.apace100.origins.datagen.provider;
+
+import io.github.apace100.origins.registry.OriginsBlocks;
+import io.github.apace100.origins.util.OriginsConstants;
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.client.model.generators.BlockStateProvider;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+
+public class OriginsBlockStateProvider extends BlockStateProvider {
+    public OriginsBlockStateProvider(PackOutput output, ExistingFileHelper helper) {
+        super(output, OriginsConstants.MODID, helper);
+    }
+
+    @Override
+    protected void registerStatesAndModels() {
+        simpleBlock(OriginsBlocks.ORIGIN_STONE.get());
+    }
+}

--- a/src/main/java/io/github/apace100/origins/datagen/provider/OriginsBlockTags.java
+++ b/src/main/java/io/github/apace100/origins/datagen/provider/OriginsBlockTags.java
@@ -1,0 +1,22 @@
+package io.github.apace100.origins.datagen.provider;
+
+import io.github.apace100.origins.registry.OriginsBlocks;
+import io.github.apace100.origins.util.OriginsConstants;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.tags.BlockTags;
+import net.neoforged.neoforge.common.data.BlockTagsProvider;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+
+import java.util.concurrent.CompletableFuture;
+
+public class OriginsBlockTags extends BlockTagsProvider {
+    public OriginsBlockTags(PackOutput output, CompletableFuture<HolderLookup.Provider> lookup, ExistingFileHelper helper) {
+        super(output, lookup, OriginsConstants.MODID, helper);
+    }
+
+    @Override
+    protected void addTags(HolderLookup.Provider provider) {
+        tag(BlockTags.MINEABLE_WITH_PICKAXE).add(OriginsBlocks.ORIGIN_STONE.get());
+    }
+}

--- a/src/main/java/io/github/apace100/origins/datagen/provider/OriginsItemModelProvider.java
+++ b/src/main/java/io/github/apace100/origins/datagen/provider/OriginsItemModelProvider.java
@@ -1,0 +1,19 @@
+package io.github.apace100.origins.datagen.provider;
+
+import io.github.apace100.origins.registry.OriginsItems;
+import io.github.apace100.origins.util.OriginsConstants;
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.client.model.generators.ItemModelProvider;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+
+public class OriginsItemModelProvider extends ItemModelProvider {
+    public OriginsItemModelProvider(PackOutput output, ExistingFileHelper helper) {
+        super(output, OriginsConstants.MODID, helper);
+    }
+
+    @Override
+    protected void registerModels() {
+        basicItem(OriginsItems.ORB_OF_ORIGIN.get());
+        basicItem(OriginsItems.ORIGIN_STONE.get());
+    }
+}

--- a/src/main/java/io/github/apace100/origins/datagen/provider/OriginsItemTags.java
+++ b/src/main/java/io/github/apace100/origins/datagen/provider/OriginsItemTags.java
@@ -1,0 +1,24 @@
+package io.github.apace100.origins.datagen.provider;
+
+import io.github.apace100.origins.registry.OriginsItems;
+import io.github.apace100.origins.util.OriginsConstants;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.tags.ItemTagsProvider;
+import net.minecraft.data.tags.TagsProvider;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+
+import java.util.concurrent.CompletableFuture;
+
+public class OriginsItemTags extends ItemTagsProvider {
+    public OriginsItemTags(PackOutput output, CompletableFuture<HolderLookup.Provider> lookup, CompletableFuture<TagsProvider.TagLookup<Block>> blockTags, ExistingFileHelper helper) {
+        super(output, lookup, blockTags, OriginsConstants.MODID, helper);
+    }
+
+    @Override
+    protected void addTags(HolderLookup.Provider provider) {
+        tag(ItemTags.BOOKSHELF_BOOKS).add(OriginsItems.ORB_OF_ORIGIN.get());
+    }
+}

--- a/src/main/java/io/github/apace100/origins/datagen/provider/OriginsLanguageProvider.java
+++ b/src/main/java/io/github/apace100/origins/datagen/provider/OriginsLanguageProvider.java
@@ -1,0 +1,19 @@
+package io.github.apace100.origins.datagen.provider;
+
+import io.github.apace100.origins.registry.OriginsBlocks;
+import io.github.apace100.origins.registry.OriginsItems;
+import io.github.apace100.origins.util.OriginsConstants;
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.common.data.LanguageProvider;
+
+public class OriginsLanguageProvider extends LanguageProvider {
+    public OriginsLanguageProvider(PackOutput output) {
+        super(output, OriginsConstants.MODID, "en_us");
+    }
+
+    @Override
+    protected void addTranslations() {
+        add(OriginsBlocks.ORIGIN_STONE.get(), "Origin Stone");
+        add(OriginsItems.ORB_OF_ORIGIN.get(), "Orb of Origin");
+    }
+}

--- a/src/main/java/io/github/apace100/origins/datagen/provider/OriginsLootTableProvider.java
+++ b/src/main/java/io/github/apace100/origins/datagen/provider/OriginsLootTableProvider.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.datagen.provider;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.loot.LootTableProvider;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+public class OriginsLootTableProvider extends LootTableProvider {
+    public OriginsLootTableProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookup) {
+        super(output, Set.of(), List.of(new SubProviderEntry(OriginsBlockLootTables::new, LootContextParamSets.BLOCK)), lookup);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/datagen/provider/OriginsRecipeProvider.java
+++ b/src/main/java/io/github/apace100/origins/datagen/provider/OriginsRecipeProvider.java
@@ -1,0 +1,37 @@
+package io.github.apace100.origins.datagen.provider;
+
+import io.github.apace100.origins.registry.OriginsBlocks;
+import io.github.apace100.origins.registry.OriginsItems;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.recipes.RecipeCategory;
+import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.data.recipes.RecipeProvider;
+import net.minecraft.data.recipes.ShapedRecipeBuilder;
+import net.minecraft.data.recipes.ShapelessRecipeBuilder;
+import net.minecraft.world.item.Items;
+
+import java.util.concurrent.CompletableFuture;
+
+public class OriginsRecipeProvider extends RecipeProvider {
+    public OriginsRecipeProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookup) {
+        super(output, lookup);
+    }
+
+    @Override
+    protected void buildRecipes(RecipeOutput output) {
+        ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, OriginsItems.ORB_OF_ORIGIN.get())
+            .requires(Items.AMETHYST_SHARD)
+            .requires(Items.ENDER_PEARL)
+            .requires(Items.BOOK)
+            .unlockedBy("has_ender_pearl", has(Items.ENDER_PEARL))
+            .save(output);
+
+        ShapedRecipeBuilder.shaped(RecipeCategory.BUILDING_BLOCKS, OriginsBlocks.ORIGIN_STONE.get(), 4)
+            .define('#', Items.AMETHYST_BLOCK)
+            .pattern("##")
+            .pattern("##")
+            .unlockedBy("has_amethyst", has(Items.AMETHYST_BLOCK))
+            .save(output);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/network/OriginSyncPayload.java
+++ b/src/main/java/io/github/apace100/origins/network/OriginSyncPayload.java
@@ -1,0 +1,36 @@
+package io.github.apace100.origins.network;
+
+import io.github.apace100.origins.util.OriginsConstants;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+
+public record OriginSyncPayload(ResourceLocation originId) implements CustomPacketPayload {
+    public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(OriginsConstants.MODID, "sync_origin");
+    public static final Type<OriginSyncPayload> TYPE = new Type<>(ID);
+    public static final StreamCodec<RegistryFriendlyByteBuf, OriginSyncPayload> STREAM_CODEC = StreamCodec.of(OriginSyncPayload::write, OriginSyncPayload::read);
+
+    private static OriginSyncPayload read(RegistryFriendlyByteBuf buf) {
+        ResourceLocation origin = null;
+        if (buf.readBoolean()) {
+            origin = buf.readResourceLocation();
+        }
+        return new OriginSyncPayload(origin);
+    }
+
+    private static void write(RegistryFriendlyByteBuf buf, OriginSyncPayload payload) {
+        ResourceLocation origin = payload.originId();
+        if (origin != null) {
+            buf.writeBoolean(true);
+            buf.writeResourceLocation(origin);
+        } else {
+            buf.writeBoolean(false);
+        }
+    }
+
+    @Override
+    public Type<OriginSyncPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/network/OriginsNetwork.java
+++ b/src/main/java/io/github/apace100/origins/network/OriginsNetwork.java
@@ -1,0 +1,28 @@
+package io.github.apace100.origins.network;
+
+import io.github.apace100.origins.util.OriginsConstants;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+import net.neoforged.neoforge.network.registration.PayloadRegistrar;
+
+@EventBusSubscriber(modid = OriginsConstants.MODID, bus = EventBusSubscriber.Bus.MOD)
+public final class OriginsNetwork {
+    private static final String NETWORK_VERSION = "1";
+
+    private OriginsNetwork() {
+    }
+
+    @SubscribeEvent
+    public static void register(RegisterPayloadHandlersEvent event) {
+        PayloadRegistrar registrar = event.registrar(NETWORK_VERSION);
+        registrar.playToClient(OriginSyncPayload.TYPE, OriginSyncPayload.STREAM_CODEC, OriginsNetwork::handleSync);
+    }
+
+    private static void handleSync(OriginSyncPayload payload, IPayloadContext context) {
+        context.enqueueWork(() -> {
+            // Client-side sync placeholder
+        });
+    }
+}

--- a/src/main/java/io/github/apace100/origins/platform/OriginsNeoForge.java
+++ b/src/main/java/io/github/apace100/origins/platform/OriginsNeoForge.java
@@ -1,0 +1,26 @@
+package io.github.apace100.origins.platform;
+
+import io.github.apace100.origins.config.OriginsConfig;
+import io.github.apace100.origins.registry.OriginsActions;
+import io.github.apace100.origins.registry.OriginsBlocks;
+import io.github.apace100.origins.registry.OriginsConditions;
+import io.github.apace100.origins.registry.OriginsItems;
+import io.github.apace100.origins.registry.OriginsPowers;
+import io.github.apace100.origins.util.OriginsConstants;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.config.ModConfig;
+
+@Mod(OriginsConstants.MODID)
+public final class OriginsNeoForge {
+    public OriginsNeoForge(IEventBus modEventBus, ModContainer container) {
+        OriginsBlocks.BLOCKS.register(modEventBus);
+        OriginsItems.ITEMS.register(modEventBus);
+        OriginsPowers.POWERS.register(modEventBus);
+        OriginsActions.ACTIONS.register(modEventBus);
+        OriginsConditions.CONDITIONS.register(modEventBus);
+
+        container.registerConfig(ModConfig.Type.COMMON, OriginsConfig.COMMON_SPEC);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/registry/OriginsActions.java
+++ b/src/main/java/io/github/apace100/origins/registry/OriginsActions.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.registry;
+
+import com.mojang.serialization.Codec;
+import io.github.apace100.origins.util.OriginsConstants;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+public final class OriginsActions {
+    public static final ResourceKey<Registry<Codec<?>>> ACTION_REGISTRY = ResourceKey.createRegistryKey(ResourceLocation.fromNamespaceAndPath(OriginsConstants.MODID, "actions"));
+    public static final DeferredRegister<Codec<?>> ACTIONS = DeferredRegister.create(ACTION_REGISTRY, OriginsConstants.MODID);
+
+    private OriginsActions() {
+    }
+}

--- a/src/main/java/io/github/apace100/origins/registry/OriginsBlocks.java
+++ b/src/main/java/io/github/apace100/origins/registry/OriginsBlocks.java
@@ -1,0 +1,24 @@
+package io.github.apace100.origins.registry;
+
+import io.github.apace100.origins.util.OriginsConstants;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.material.MapColor;
+import net.minecraft.world.level.material.PushReaction;
+import net.neoforged.neoforge.registries.DeferredBlock;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+public final class OriginsBlocks {
+    public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(OriginsConstants.MODID);
+
+    public static final DeferredBlock<Block> ORIGIN_STONE = BLOCKS.register("origin_stone", () -> new Block(BlockBehaviour.Properties.ofFullCopy(Blocks.STONE)
+        .mapColor(MapColor.COLOR_CYAN)
+        .strength(1.5F, 6.0F)
+        .sound(SoundType.STONE)
+        .pushReaction(PushReaction.NORMAL)));
+
+    private OriginsBlocks() {
+    }
+}

--- a/src/main/java/io/github/apace100/origins/registry/OriginsConditions.java
+++ b/src/main/java/io/github/apace100/origins/registry/OriginsConditions.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.registry;
+
+import com.mojang.serialization.Codec;
+import io.github.apace100.origins.util.OriginsConstants;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+public final class OriginsConditions {
+    public static final ResourceKey<Registry<Codec<?>>> CONDITION_REGISTRY = ResourceKey.createRegistryKey(ResourceLocation.fromNamespaceAndPath(OriginsConstants.MODID, "conditions"));
+    public static final DeferredRegister<Codec<?>> CONDITIONS = DeferredRegister.create(CONDITION_REGISTRY, OriginsConstants.MODID);
+
+    private OriginsConditions() {
+    }
+}

--- a/src/main/java/io/github/apace100/origins/registry/OriginsItems.java
+++ b/src/main/java/io/github/apace100/origins/registry/OriginsItems.java
@@ -1,0 +1,18 @@
+package io.github.apace100.origins.registry;
+
+import io.github.apace100.origins.util.OriginsConstants;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Rarity;
+import net.neoforged.neoforge.registries.DeferredItem;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+public final class OriginsItems {
+    public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(OriginsConstants.MODID);
+
+    public static final DeferredItem<Item> ORB_OF_ORIGIN = ITEMS.register("orb_of_origin", () -> new Item(new Item.Properties().stacksTo(1).rarity(Rarity.UNCOMMON)));
+    public static final DeferredItem<BlockItem> ORIGIN_STONE = ITEMS.registerSimpleBlockItem(OriginsBlocks.ORIGIN_STONE);
+
+    private OriginsItems() {
+    }
+}

--- a/src/main/java/io/github/apace100/origins/registry/OriginsPowers.java
+++ b/src/main/java/io/github/apace100/origins/registry/OriginsPowers.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.registry;
+
+import com.mojang.serialization.Codec;
+import io.github.apace100.origins.util.OriginsConstants;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+public final class OriginsPowers {
+    public static final ResourceKey<Registry<Codec<?>>> POWER_REGISTRY = ResourceKey.createRegistryKey(ResourceLocation.fromNamespaceAndPath(OriginsConstants.MODID, "powers"));
+    public static final DeferredRegister<Codec<?>> POWERS = DeferredRegister.create(POWER_REGISTRY, OriginsConstants.MODID);
+
+    private OriginsPowers() {
+    }
+}

--- a/src/main/java/io/github/apace100/origins/util/OriginsConstants.java
+++ b/src/main/java/io/github/apace100/origins/util/OriginsConstants.java
@@ -1,0 +1,8 @@
+package io.github.apace100.origins.util;
+
+public final class OriginsConstants {
+    public static final String MODID = "origins";
+
+    private OriginsConstants() {
+    }
+}

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,20 +1,8 @@
-modLoader="neoforge"
-loaderVersion="[21,)"
+modLoader="javafml"
+loaderVersion="[1,)"
 license="MIT"
-issueTrackerURL="https://github.com/apace100/origins/issues"
-
 [[mods]]
 modId="origins"
-version="${modVersion}"
+version="${version}"
 displayName="Origins (NeoForge)"
-authors="Apace100, Contributors"
-description='''
-Origins mod ported to NeoForge.
-'''
-
-[[dependencies.origins]]
-modId="neoforge"
-mandatory=true
-versionRange="[21.1,)"
-ordering="NONE"
-side="BOTH"
+description="Port of the Origins mod to NeoForge."

--- a/src/main/resources/assets/origins/lang/en_us.json
+++ b/src/main/resources/assets/origins/lang/en_us.json
@@ -1,5 +1,4 @@
 {
   "item.origins.orb_of_origin": "Orb of Origin",
-  "block.origins.origin_stone": "Origin Stone",
-  "commands.origins.reload_soon": "Origins data reload support is coming soon"
+  "block.origins.origin_stone": "Origin Stone"
 }

--- a/src/main/resources/assets/origins/models/block/origin_stone.json
+++ b/src/main/resources/assets/origins/models/block/origin_stone.json
@@ -1,6 +1,6 @@
 {
-  "parent": "minecraft:block/cube_all",
+  "parent": "block/cube_all",
   "textures": {
-    "all": "minecraft:block/stone"
+    "all": "origins:block/origin_stone"
   }
 }

--- a/src/main/resources/assets/origins/models/item/orb_of_origin.json
+++ b/src/main/resources/assets/origins/models/item/orb_of_origin.json
@@ -1,6 +1,6 @@
 {
-  "parent": "minecraft:item/generated",
+  "parent": "item/generated",
   "textures": {
-    "layer0": "minecraft:item/ender_pearl"
+    "layer0": "origins:item/orb_of_origin"
   }
 }

--- a/src/main/resources/data/origins/loot_tables/blocks/origin_stone.json
+++ b/src/main/resources/data/origins/loot_tables/blocks/origin_stone.json
@@ -2,14 +2,13 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
+      "rolls": 1,
       "entries": [
         {
           "type": "minecraft:item",
           "name": "origins:origin_stone"
         }
-      ],
-      "rolls": 1.0
+      ]
     }
   ]
 }

--- a/src/main/resources/data/origins/recipes/orb_of_origin.json
+++ b/src/main/resources/data/origins/recipes/orb_of_origin.json
@@ -3,8 +3,8 @@
   "category": "misc",
   "ingredients": [
     { "item": "minecraft:amethyst_shard" },
-    { "item": "minecraft:ender_eye" },
-    { "item": "minecraft:ghast_tear" }
+    { "item": "minecraft:ender_pearl" },
+    { "item": "minecraft:book" }
   ],
   "result": {
     "item": "origins:orb_of_origin"

--- a/src/main/resources/data/origins/recipes/origin_stone.json
+++ b/src/main/resources/data/origins/recipes/origin_stone.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "minecraft:stone"
+      "item": "minecraft:amethyst_block"
     }
   },
   "result": {


### PR DESCRIPTION
## Summary
- configure Gradle for the NeoForge 1.21.1 toolchain and streamline resource processing
- add mod entrypoint, registry scaffolding, capability plumbing, networking, and command hooks for Origins
- provide initial datagen providers plus placeholder assets, loot tables, and recipes for Origin Stone and the Orb of Origin

## Testing
- ./gradlew --console=plain compileJava

------
https://chatgpt.com/codex/tasks/task_e_68dc60c13c5083278e735fee8a340e8c