### PR TITLE
Implement origin selection, networking, and data-driven loaders

### DIFF
--- a/src/main/java/io/github/apace100/origins/Origins.java
+++ b/src/main/java/io/github/apace100/origins/Origins.java
@@ -1,8 +1,17 @@
 package io.github.apace100.origins;
 
+import com.mojang.logging.LogUtils;
+import net.minecraft.resources.ResourceLocation;
+import org.slf4j.Logger;
+
 public final class Origins {
     public static final String MOD_ID = "origins";
+    public static final Logger LOGGER = LogUtils.getLogger();
 
     private Origins() {
+    }
+
+    public static ResourceLocation id(String path) {
+        return ResourceLocation.fromNamespaceAndPath(MOD_ID, path);
     }
 }

--- a/src/main/java/io/github/apace100/origins/client/OriginsClient.java
+++ b/src/main/java/io/github/apace100/origins/client/OriginsClient.java
@@ -1,0 +1,61 @@
+package io.github.apace100.origins.client;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.client.config.OriginsClientConfig;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.player.LocalPlayer;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
+import net.neoforged.neoforge.event.TickEvent;
+
+public final class OriginsClient {
+    private static KeyMapping openOriginScreen;
+
+    private OriginsClient() {
+    }
+
+    public static void init() {
+        OriginsClientConfig.register();
+    }
+
+    @EventBusSubscriber(modid = Origins.MOD_ID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+    public static final class ModEvents {
+        private ModEvents() {
+        }
+
+        @SubscribeEvent
+        public static void onRegisterKeyMappings(RegisterKeyMappingsEvent event) {
+            openOriginScreen = new KeyMapping(
+                "key.origins.open_selection",
+                InputConstants.KEY_O,
+                "key.categories.origins"
+            );
+            event.register(openOriginScreen);
+        }
+    }
+
+    @EventBusSubscriber(modid = Origins.MOD_ID, bus = EventBusSubscriber.Bus.GAME, value = Dist.CLIENT)
+    public static final class ForgeEvents {
+        private ForgeEvents() {
+        }
+
+        @SubscribeEvent
+        public static void onClientTick(TickEvent.ClientTickEvent event) {
+            if (event.phase != TickEvent.Phase.END || openOriginScreen == null) {
+                return;
+            }
+
+            if (openOriginScreen.consumeClick()) {
+                Minecraft minecraft = Minecraft.getInstance();
+                LocalPlayer player = minecraft.player;
+                if (player != null) {
+                    OriginsClientHooks.openOriginScreen(player.getMainHandItem());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/apace100/origins/client/OriginsClientHooks.java
+++ b/src/main/java/io/github/apace100/origins/client/OriginsClientHooks.java
@@ -1,0 +1,19 @@
+package io.github.apace100.origins.client;
+
+import io.github.apace100.origins.client.gui.OriginSelectionScreen;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.item.ItemStack;
+
+public final class OriginsClientHooks {
+    private OriginsClientHooks() {
+    }
+
+    public static void openOriginScreen(ItemStack stack) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.player == null) {
+            return;
+        }
+
+        minecraft.setScreen(new OriginSelectionScreen(stack));
+    }
+}

--- a/src/main/java/io/github/apace100/origins/client/config/OriginsClientConfig.java
+++ b/src/main/java/io/github/apace100/origins/client/config/OriginsClientConfig.java
@@ -1,0 +1,36 @@
+package io.github.apace100.origins.client.config;
+
+import io.github.apace100.origins.Origins;
+import net.neoforged.fml.ModLoadingContext;
+import net.neoforged.fml.config.ModConfig;
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public final class OriginsClientConfig {
+    public static final ModConfigSpec SPEC;
+    public static final Client CLIENT;
+
+    static {
+        ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
+        CLIENT = new Client(builder);
+        SPEC = builder.build();
+    }
+
+    private OriginsClientConfig() {
+    }
+
+    public static void register() {
+        ModLoadingContext.get().getActiveContainer().registerConfig(ModConfig.Type.CLIENT, SPEC, Origins.MOD_ID + "-client.toml");
+    }
+
+    public static final class Client {
+        public final ModConfigSpec.BooleanValue showOriginReminder;
+
+        private Client(ModConfigSpec.Builder builder) {
+            builder.push("ui");
+            showOriginReminder = builder
+                .comment("If true, Origins displays a reminder tooltip when holding the Orb of Origin.")
+                .define("showOriginReminder", true);
+            builder.pop();
+        }
+    }
+}

--- a/src/main/java/io/github/apace100/origins/client/gui/OriginSelectionScreen.java
+++ b/src/main/java/io/github/apace100/origins/client/gui/OriginSelectionScreen.java
@@ -1,0 +1,112 @@
+package io.github.apace100.origins.client.gui;
+
+import io.github.apace100.origins.common.network.ChooseOriginC2S;
+import io.github.apace100.origins.common.network.ModNetworking;
+import io.github.apace100.origins.common.origin.Origin;
+import io.github.apace100.origins.common.registry.OriginRegistry;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.CycleButton;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+public class OriginSelectionScreen extends Screen {
+    private static final Component TITLE = Component.translatable("screen.origins.select_origin");
+    private static final Component CONFIRM = Component.translatable("screen.origins.confirm");
+    private static final Component RESET = Component.translatable("screen.origins.reset");
+    private static final Component NONE = Component.translatable("screen.origins.none");
+
+    private final ItemStack heldStack;
+    private List<Origin> origins = List.of();
+    private Origin selected;
+    private CycleButton<Optional<Origin>> originCycle;
+    private Button confirmButton;
+
+    public OriginSelectionScreen(ItemStack heldStack) {
+        super(TITLE);
+        this.heldStack = heldStack.copy();
+    }
+
+    @Override
+    protected void init() {
+        origins = new ArrayList<>(OriginRegistry.values());
+        origins.sort(Comparator.comparing(origin -> origin.id().toString()));
+
+        Optional<Origin> initial = origins.isEmpty() ? Optional.empty() : Optional.of(origins.get(0));
+        selected = initial.orElse(null);
+
+        originCycle = addRenderableWidget(CycleButton.<Optional<Origin>>builder(value -> value.map(Origin::name).orElse(NONE))
+            .withValues(buildOptions())
+            .withInitialValue(initial)
+            .displayOnlyValue()
+            .create(width / 2 - 100, height / 2 - 30, 200, 20, Component.translatable("screen.origins.origin"),
+                (button, value) -> selected = value.orElse(null)));
+
+        confirmButton = addRenderableWidget(Button.builder(CONFIRM, button -> confirmSelection())
+            .bounds(width / 2 - 100, height / 2, 200, 20)
+            .build());
+
+        addRenderableWidget(Button.builder(RESET, button -> {
+            ModNetworking.sendToServer(new ChooseOriginC2S(Optional.empty()));
+            onClose();
+        }).bounds(width / 2 - 100, height / 2 + 24, 200, 20).build());
+
+        confirmButton.active = selected != null;
+    }
+
+    private List<Optional<Origin>> buildOptions() {
+        List<Optional<Origin>> options = new ArrayList<>();
+        options.add(Optional.empty());
+        origins.forEach(origin -> options.add(Optional.of(origin)));
+        return options;
+    }
+
+    private void confirmSelection() {
+        if (selected != null) {
+            ModNetworking.sendToServer(new ChooseOriginC2S(Optional.of(selected.id())));
+        }
+        onClose();
+    }
+
+    @Override
+    public void tick() {
+        super.tick();
+        if (originCycle != null) {
+            confirmButton.active = selected != null;
+        }
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        renderBackground(graphics);
+        super.render(graphics, mouseX, mouseY, partialTick);
+        graphics.drawCenteredString(font, title, width / 2, height / 2 - 60, 0xFFFFFF);
+        if (selected != null) {
+            graphics.drawCenteredString(font, selected.description(), width / 2, height / 2 - 10, 0xAAAAAA);
+        } else {
+            graphics.drawCenteredString(font, Component.translatable("screen.origins.no_selection"), width / 2, height / 2 - 10, 0xAAAAAA);
+        }
+    }
+
+    @Override
+    public boolean shouldCloseOnEsc() {
+        return true;
+    }
+
+    @Override
+    public void onClose() {
+        super.onClose();
+        Minecraft.getInstance().setScreen(null);
+    }
+
+    public ItemStack getHeldStack() {
+        return heldStack;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/action/ConfiguredAction.java
+++ b/src/main/java/io/github/apace100/origins/common/action/ConfiguredAction.java
@@ -1,0 +1,10 @@
+package io.github.apace100.origins.common.action;
+
+import io.github.apace100.origins.api.Action;
+import net.minecraft.resources.ResourceLocation;
+
+public record ConfiguredAction(ResourceLocation type, Action<Void> action) {
+    public void run() {
+        action.run(null);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/commands/ModCommands.java
+++ b/src/main/java/io/github/apace100/origins/common/commands/ModCommands.java
@@ -1,16 +1,30 @@
 package io.github.apace100.origins.common.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.common.origin.Origin;
+import io.github.apace100.origins.common.registry.OriginRegistry;
+import io.github.apace100.origins.neoforge.capability.PlayerOriginManager;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.commands.arguments.ResourceLocationArgument;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 
 @EventBusSubscriber(modid = Origins.MOD_ID, bus = EventBusSubscriber.Bus.GAME)
 public final class ModCommands {
+    private static final DynamicCommandExceptionType ERROR_UNKNOWN_ORIGIN = new DynamicCommandExceptionType(id ->
+        Component.translatable("commands.origins.error.unknown", id)
+    );
+
     private ModCommands() {
     }
 
@@ -28,6 +42,60 @@ public final class ModCommands {
                     source.sendSuccess(() -> Component.translatable("commands.origins.reload_soon"), true);
                     return 1;
                 }))
+                .then(Commands.literal("list").executes(context -> listOrigins(context.getSource())))
+                .then(Commands.literal("set")
+                    .then(Commands.argument("player", EntityArgument.player())
+                        .then(Commands.argument("origin", ResourceLocationArgument.id())
+                            .suggests((ctx, builder) -> SharedSuggestionProvider.suggest(
+                                OriginRegistry.ids().stream().map(ResourceLocation::toString).toList(), builder
+                            ))
+                            .executes(context -> setOrigin(
+                                context.getSource(),
+                                EntityArgument.getPlayer(context, "player"),
+                                ResourceLocationArgument.getId(context, "origin")
+                            )))))
+                .then(Commands.literal("reset")
+                    .then(Commands.argument("player", EntityArgument.player())
+                        .executes(context -> resetOrigin(
+                            context.getSource(),
+                            EntityArgument.getPlayer(context, "player")
+                        ))))
         );
+    }
+
+    private static int listOrigins(CommandSourceStack source) {
+        var origins = OriginRegistry.values();
+        if (origins.isEmpty()) {
+            source.sendSuccess(() -> Component.translatable("commands.origins.list.empty"), false);
+            return 0;
+        }
+
+        source.sendSuccess(() -> Component.translatable("commands.origins.list.header", origins.size()), false);
+        origins.stream()
+            .sorted((a, b) -> a.id().compareTo(b.id()))
+            .forEach(origin -> source.sendSuccess(() -> describeOrigin(origin), false));
+        return origins.size();
+    }
+
+    private static Component describeOrigin(Origin origin) {
+        return Component.translatable(
+            "commands.origins.list.entry",
+            origin.name(),
+            origin.id().toString(),
+            origin.powers().size()
+        );
+    }
+
+    private static int setOrigin(CommandSourceStack source, ServerPlayer player, ResourceLocation originId) throws CommandSyntaxException {
+        Origin origin = OriginRegistry.get(originId).orElseThrow(() -> ERROR_UNKNOWN_ORIGIN.create(originId));
+        PlayerOriginManager.set(player, origin.id());
+        source.sendSuccess(() -> Component.translatable("commands.origins.set", player.getDisplayName(), origin.name()), true);
+        return 1;
+    }
+
+    private static int resetOrigin(CommandSourceStack source, ServerPlayer player) {
+        PlayerOriginManager.clear(player);
+        source.sendSuccess(() -> Component.translatable("commands.origins.reset", player.getDisplayName()), true);
+        return 1;
     }
 }

--- a/src/main/java/io/github/apace100/origins/common/condition/ConfiguredCondition.java
+++ b/src/main/java/io/github/apace100/origins/common/condition/ConfiguredCondition.java
@@ -1,0 +1,10 @@
+package io.github.apace100.origins.common.condition;
+
+import io.github.apace100.origins.api.Condition;
+import net.minecraft.resources.ResourceLocation;
+
+public record ConfiguredCondition(ResourceLocation type, Condition<Void> condition) {
+    public boolean test() {
+        return condition.test(null);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/data/CodecJsonReloadListener.java
+++ b/src/main/java/io/github/apace100/origins/common/data/CodecJsonReloadListener.java
@@ -1,0 +1,56 @@
+package io.github.apace100.origins.common.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.JsonOps;
+import io.github.apace100.origins.Origins;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.util.profiling.ProfilerFiller;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public abstract class CodecJsonReloadListener<T> extends SimpleJsonResourceReloadListener {
+    private static final Gson GSON = new GsonBuilder().setLenient().create();
+
+    protected CodecJsonReloadListener(String directory) {
+        super(GSON, directory);
+    }
+
+    @Override
+    protected void apply(Map<ResourceLocation, JsonElement> object, ResourceManager resourceManager, ProfilerFiller profiler) {
+        Map<ResourceLocation, T> resolved = new HashMap<>();
+        object.forEach((id, element) -> decodeEntry(id, element, resolved::put));
+        applyResolved(resolved);
+    }
+
+    private void decodeEntry(ResourceLocation id, JsonElement element, BiConsumer<ResourceLocation, T> registrar) {
+        JsonObject json = GsonHelper.convertToJsonObject(element, "value");
+        ResourceLocation typeId = ResourceLocation.parse(GsonHelper.getAsString(json, "type"));
+        Codec<? extends T> codec = resolveCodec(typeId);
+        if (codec == null) {
+            Origins.LOGGER.warn("Unknown codec '{}' for data file '{}'", typeId, id);
+            return;
+        }
+
+        DataResult<? extends T> result = codec.parse(JsonOps.INSTANCE, json);
+        result.resultOrPartial(message -> Origins.LOGGER.error("Failed to decode {}: {}", id, message))
+            .ifPresent(value -> registrar.accept(id, wrap(typeId, value)));
+    }
+
+    protected abstract Codec<? extends T> resolveCodec(ResourceLocation typeId);
+
+    protected T wrap(ResourceLocation typeId, T value) {
+        return value;
+    }
+
+    protected abstract void applyResolved(Map<ResourceLocation, T> values);
+}

--- a/src/main/java/io/github/apace100/origins/common/data/ConfiguredActionLoader.java
+++ b/src/main/java/io/github/apace100/origins/common/data/ConfiguredActionLoader.java
@@ -1,0 +1,38 @@
+package io.github.apace100.origins.common.data;
+
+import com.mojang.serialization.Codec;
+import io.github.apace100.origins.api.Action;
+import io.github.apace100.origins.common.action.ConfiguredAction;
+import io.github.apace100.origins.common.registry.ConfiguredActions;
+import io.github.apace100.origins.common.registry.ModActions;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.registries.DeferredHolder;
+
+import java.util.Map;
+
+public final class ConfiguredActionLoader extends CodecJsonReloadListener<ConfiguredAction> {
+    public ConfiguredActionLoader() {
+        super("origins/actions");
+    }
+
+    @Override
+    protected Codec<? extends ConfiguredAction> resolveCodec(ResourceLocation typeId) {
+        Codec<Action<Void>> codec = findCodec(typeId);
+        return codec == null ? null : codec.xmap(action -> new ConfiguredAction(typeId, action), ConfiguredAction::action);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Codec<Action<Void>> findCodec(ResourceLocation typeId) {
+        for (DeferredHolder<Codec<?>, Codec<?>> holder : ModActions.ACTIONS.getEntries()) {
+            if (holder.getId().equals(typeId)) {
+                return (Codec<Action<Void>>) holder.get();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected void applyResolved(Map<ResourceLocation, ConfiguredAction> values) {
+        ConfiguredActions.setAll(values);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/data/ConfiguredConditionLoader.java
+++ b/src/main/java/io/github/apace100/origins/common/data/ConfiguredConditionLoader.java
@@ -1,0 +1,38 @@
+package io.github.apace100.origins.common.data;
+
+import com.mojang.serialization.Codec;
+import io.github.apace100.origins.api.Condition;
+import io.github.apace100.origins.common.condition.ConfiguredCondition;
+import io.github.apace100.origins.common.registry.ConfiguredConditions;
+import io.github.apace100.origins.common.registry.ModConditions;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.registries.DeferredHolder;
+
+import java.util.Map;
+
+public final class ConfiguredConditionLoader extends CodecJsonReloadListener<ConfiguredCondition> {
+    public ConfiguredConditionLoader() {
+        super("origins/conditions");
+    }
+
+    @Override
+    protected Codec<? extends ConfiguredCondition> resolveCodec(ResourceLocation typeId) {
+        Codec<Condition<Void>> codec = findCodec(typeId);
+        return codec == null ? null : codec.xmap(condition -> new ConfiguredCondition(typeId, condition), ConfiguredCondition::condition);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Codec<Condition<Void>> findCodec(ResourceLocation typeId) {
+        for (DeferredHolder<Codec<?>, Codec<?>> holder : ModConditions.CONDITIONS.getEntries()) {
+            if (holder.getId().equals(typeId)) {
+                return (Codec<Condition<Void>>) holder.get();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected void applyResolved(Map<ResourceLocation, ConfiguredCondition> values) {
+        ConfiguredConditions.setAll(values);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/data/ConfiguredPowerLoader.java
+++ b/src/main/java/io/github/apace100/origins/common/data/ConfiguredPowerLoader.java
@@ -1,0 +1,68 @@
+package io.github.apace100.origins.common.data;
+
+import com.mojang.serialization.Codec;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.common.power.ConfiguredPower;
+import io.github.apace100.origins.common.registry.ConfiguredActions;
+import io.github.apace100.origins.common.registry.ConfiguredConditions;
+import io.github.apace100.origins.common.registry.ConfiguredPowers;
+import io.github.apace100.origins.common.registry.ModPowers;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.registries.DeferredHolder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class ConfiguredPowerLoader extends CodecJsonReloadListener<ConfiguredPower> {
+    public ConfiguredPowerLoader() {
+        super("origins/powers");
+    }
+
+    @Override
+    protected Codec<? extends ConfiguredPower> resolveCodec(ResourceLocation typeId) {
+        Codec<ModPowers.PlaceholderPower> codec = findCodec(typeId);
+        if (codec == null) {
+            return null;
+        }
+
+        return codec.xmap(power -> new ConfiguredPower(typeId, power.name(), power.description(), power.actions(), power.condition()),
+            configured -> new ModPowers.PlaceholderPower(
+                configured.name(),
+                configured.description(),
+                List.copyOf(configured.actions()),
+                configured.condition()
+            ));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Codec<ModPowers.PlaceholderPower> findCodec(ResourceLocation typeId) {
+        for (DeferredHolder<Codec<?>, Codec<?>> holder : ModPowers.POWERS.getEntries()) {
+            if (holder.getId().equals(typeId)) {
+                return (Codec<ModPowers.PlaceholderPower>) holder.get();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected void applyResolved(Map<ResourceLocation, ConfiguredPower> values) {
+        Map<ResourceLocation, ConfiguredPower> validated = values.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> {
+            ConfiguredPower power = entry.getValue();
+            List<ResourceLocation> actions = power.actions().stream().filter(actionId -> {
+                boolean present = ConfiguredActions.get(actionId).isPresent();
+                if (!present) {
+                    Origins.LOGGER.warn("Power {} references unknown action {}", entry.getKey(), actionId);
+                }
+                return present;
+            }).toList();
+
+            if (ConfiguredConditions.get(power.condition()).isEmpty()) {
+                Origins.LOGGER.warn("Power {} references unknown condition {}", entry.getKey(), power.condition());
+            }
+
+            return new ConfiguredPower(power.type(), power.name(), power.description(), actions, power.condition());
+        }));
+        ConfiguredPowers.setAll(validated);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/data/OriginLoader.java
+++ b/src/main/java/io/github/apace100/origins/common/data/OriginLoader.java
@@ -1,0 +1,62 @@
+package io.github.apace100.origins.common.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.JsonOps;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.common.origin.Origin;
+import io.github.apace100.origins.common.registry.ConfiguredPowers;
+import io.github.apace100.origins.common.registry.OriginRegistry;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentSerialization;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
+import net.minecraft.util.profiling.ProfilerFiller;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class OriginLoader extends SimpleJsonResourceReloadListener {
+    private static final Gson GSON = new GsonBuilder().setLenient().create();
+    private static final Codec<OriginData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        ComponentSerialization.CODEC.fieldOf("name").forGetter(OriginData::name),
+        ComponentSerialization.CODEC.fieldOf("description").forGetter(OriginData::description),
+        ResourceLocation.CODEC.listOf().optionalFieldOf("powers", List.of()).forGetter(OriginData::powers)
+    ).apply(instance, OriginData::new));
+
+    public OriginLoader() {
+        super(GSON, "origins/origins");
+    }
+
+    @Override
+    protected void apply(Map<ResourceLocation, JsonElement> object, ResourceManager resourceManager, ProfilerFiller profiler) {
+        Map<ResourceLocation, Origin> resolved = new HashMap<>();
+        object.forEach((id, element) -> decodeOrigin(id, element)
+            .resultOrPartial(message -> Origins.LOGGER.error("Failed to decode origin {}: {}", id, message))
+            .ifPresent(origin -> resolved.put(id, origin)));
+        OriginRegistry.setAll(resolved);
+    }
+
+    private DataResult<Origin> decodeOrigin(ResourceLocation id, JsonElement element) {
+        return CODEC.parse(JsonOps.INSTANCE, element)
+            .map(data -> {
+                List<ResourceLocation> resolvedPowers = data.powers().stream().filter(powerId -> {
+                    boolean present = ConfiguredPowers.get(powerId).isPresent();
+                    if (!present) {
+                        Origins.LOGGER.warn("Origin {} references unknown power {}", id, powerId);
+                    }
+                    return present;
+                }).toList();
+                return new Origin(id, data.name(), data.description(), resolvedPowers);
+            });
+    }
+
+    private record OriginData(Component name, Component description, List<ResourceLocation> powers) {
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/data/OriginsDataReloaders.java
+++ b/src/main/java/io/github/apace100/origins/common/data/OriginsDataReloaders.java
@@ -1,0 +1,25 @@
+package io.github.apace100.origins.common.data;
+
+import io.github.apace100.origins.Origins;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.AddReloadListenerEvent;
+
+@EventBusSubscriber(modid = Origins.MOD_ID, bus = EventBusSubscriber.Bus.GAME)
+public final class OriginsDataReloaders {
+    private static final ConfiguredActionLoader ACTION_LOADER = new ConfiguredActionLoader();
+    private static final ConfiguredConditionLoader CONDITION_LOADER = new ConfiguredConditionLoader();
+    private static final ConfiguredPowerLoader POWER_LOADER = new ConfiguredPowerLoader();
+    private static final OriginLoader ORIGIN_LOADER = new OriginLoader();
+
+    private OriginsDataReloaders() {
+    }
+
+    @SubscribeEvent
+    public static void onAddReloadListeners(AddReloadListenerEvent event) {
+        event.addListener(ACTION_LOADER);
+        event.addListener(CONDITION_LOADER);
+        event.addListener(POWER_LOADER);
+        event.addListener(ORIGIN_LOADER);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/item/OrbOfOriginItem.java
+++ b/src/main/java/io/github/apace100/origins/common/item/OrbOfOriginItem.java
@@ -1,0 +1,28 @@
+package io.github.apace100.origins.common.item;
+
+import io.github.apace100.origins.client.OriginsClientHooks;
+import net.neoforged.fml.DistExecutor;
+import net.neoforged.api.distmarker.Dist;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+
+public class OrbOfOriginItem extends Item {
+    public OrbOfOriginItem(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
+        ItemStack stack = player.getItemInHand(hand);
+        if (level.isClientSide) {
+            DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> OriginsClientHooks.openOriginScreen(stack));
+            return InteractionResultHolder.success(stack);
+        }
+
+        return InteractionResultHolder.consume(stack);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/network/ChooseOriginC2S.java
+++ b/src/main/java/io/github/apace100/origins/common/network/ChooseOriginC2S.java
@@ -1,0 +1,40 @@
+package io.github.apace100.origins.common.network;
+
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.neoforge.capability.PlayerOriginManager;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+
+import java.util.Optional;
+
+public record ChooseOriginC2S(Optional<ResourceLocation> originId) implements CustomPacketPayload {
+    public static final Type<ChooseOriginC2S> TYPE = new Type<>(Origins.id("choose_origin"));
+    public static final StreamCodec<RegistryFriendlyByteBuf, ChooseOriginC2S> STREAM_CODEC = StreamCodec.composite(
+        ByteBufCodecs.optional(ResourceLocation.STREAM_CODEC), ChooseOriginC2S::originId, ChooseOriginC2S::new
+    );
+
+    @Override
+    public Type<ChooseOriginC2S> type() {
+        return TYPE;
+    }
+
+    public static void handle(ChooseOriginC2S payload, IPayloadContext context) {
+        context.enqueueWork(() -> {
+            if (!(context.player() instanceof ServerPlayer player)) {
+                return;
+            }
+
+            payload.originId().ifPresentOrElse(id -> {
+                if (!PlayerOriginManager.set(player, id)) {
+                    player.displayClientMessage(Component.translatable("commands.origins.error.unknown", id.toString()), true);
+                }
+            }, () -> PlayerOriginManager.clear(player));
+        });
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/network/ModNetworking.java
+++ b/src/main/java/io/github/apace100/origins/common/network/ModNetworking.java
@@ -2,6 +2,7 @@ package io.github.apace100.origins.common.network;
 
 import io.github.apace100.origins.Origins;
 import io.github.apace100.origins.common.config.ModConfigs;
+import io.github.apace100.origins.common.network.ChooseOriginC2S;
 import io.github.apace100.origins.neoforge.capability.PlayerOrigin;
 import io.github.apace100.origins.neoforge.capability.PlayerOriginManager;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
@@ -29,6 +30,7 @@ public final class ModNetworking {
         PayloadRegistrar registrar = event.registrar(PROTOCOL_VERSION);
         registrar.playToClient(SyncConfigS2C.TYPE, SyncConfigS2C.STREAM_CODEC, SyncConfigS2C::handle);
         registrar.playToClient(SyncOriginS2C.TYPE, SyncOriginS2C.STREAM_CODEC, SyncOriginS2C::handle);
+        registrar.playToServer(ChooseOriginC2S.TYPE, ChooseOriginC2S.STREAM_CODEC, ChooseOriginC2S::handle);
     }
 
     @SubscribeEvent

--- a/src/main/java/io/github/apace100/origins/common/network/SyncOriginS2C.java
+++ b/src/main/java/io/github/apace100/origins/common/network/SyncOriginS2C.java
@@ -12,11 +12,14 @@ import net.minecraft.world.entity.player.Player;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 
 import java.util.Optional;
+import java.util.Set;
 
-public record SyncOriginS2C(Optional<ResourceLocation> originId) implements CustomPacketPayload {
+public record SyncOriginS2C(Optional<ResourceLocation> originId, Set<ResourceLocation> powers) implements CustomPacketPayload {
     public static final Type<SyncOriginS2C> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "sync_origin"));
     public static final StreamCodec<RegistryFriendlyByteBuf, SyncOriginS2C> STREAM_CODEC = StreamCodec.composite(
-        ByteBufCodecs.optional(ResourceLocation.STREAM_CODEC), SyncOriginS2C::originId, SyncOriginS2C::new
+        ByteBufCodecs.optional(ResourceLocation.STREAM_CODEC), SyncOriginS2C::originId,
+        ByteBufCodecs.collection(java.util.HashSet::new, ResourceLocation.STREAM_CODEC), SyncOriginS2C::powers,
+        SyncOriginS2C::new
     );
 
     @Override
@@ -25,7 +28,7 @@ public record SyncOriginS2C(Optional<ResourceLocation> originId) implements Cust
     }
 
     public static SyncOriginS2C from(PlayerOrigin origin) {
-        return new SyncOriginS2C(origin.getOriginIdOptional());
+        return new SyncOriginS2C(origin.getOriginIdOptional(), Set.copyOf(origin.getPowers()));
     }
 
     public static void handle(SyncOriginS2C payload, IPayloadContext context) {
@@ -38,6 +41,7 @@ public record SyncOriginS2C(Optional<ResourceLocation> originId) implements Cust
             PlayerOrigin origin = player.getCapability(OriginCapabilities.PLAYER_ORIGIN);
             if (origin != null) {
                 origin.setOriginId(payload.originId().orElse(null));
+                origin.setPowers(Set.copyOf(payload.powers()));
             }
         });
     }

--- a/src/main/java/io/github/apace100/origins/common/origin/Origin.java
+++ b/src/main/java/io/github/apace100/origins/common/origin/Origin.java
@@ -1,0 +1,9 @@
+package io.github.apace100.origins.common.origin;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.List;
+
+public record Origin(ResourceLocation id, Component name, Component description, List<ResourceLocation> powers) {
+}

--- a/src/main/java/io/github/apace100/origins/common/power/ConfiguredPower.java
+++ b/src/main/java/io/github/apace100/origins/common/power/ConfiguredPower.java
@@ -1,0 +1,15 @@
+package io.github.apace100.origins.common.power;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.List;
+
+public record ConfiguredPower(
+    ResourceLocation type,
+    Component name,
+    Component description,
+    List<ResourceLocation> actions,
+    ResourceLocation condition
+) {
+}

--- a/src/main/java/io/github/apace100/origins/common/registry/ConfiguredActions.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/ConfiguredActions.java
@@ -1,0 +1,26 @@
+package io.github.apace100.origins.common.registry;
+
+import io.github.apace100.origins.common.action.ConfiguredAction;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Map;
+import java.util.Optional;
+
+public final class ConfiguredActions {
+    private static final ConfiguredRegistry<ConfiguredAction> ACTIONS = new ConfiguredRegistry<>();
+
+    private ConfiguredActions() {
+    }
+
+    public static void setAll(Map<ResourceLocation, ConfiguredAction> actions) {
+        ACTIONS.setAll(actions);
+    }
+
+    public static Optional<ConfiguredAction> get(ResourceLocation id) {
+        return ACTIONS.get(id);
+    }
+
+    public static Iterable<ResourceLocation> ids() {
+        return ACTIONS.ids();
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/registry/ConfiguredConditions.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/ConfiguredConditions.java
@@ -1,0 +1,26 @@
+package io.github.apace100.origins.common.registry;
+
+import io.github.apace100.origins.common.condition.ConfiguredCondition;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Map;
+import java.util.Optional;
+
+public final class ConfiguredConditions {
+    private static final ConfiguredRegistry<ConfiguredCondition> CONDITIONS = new ConfiguredRegistry<>();
+
+    private ConfiguredConditions() {
+    }
+
+    public static void setAll(Map<ResourceLocation, ConfiguredCondition> conditions) {
+        CONDITIONS.setAll(conditions);
+    }
+
+    public static Optional<ConfiguredCondition> get(ResourceLocation id) {
+        return CONDITIONS.get(id);
+    }
+
+    public static Iterable<ResourceLocation> ids() {
+        return CONDITIONS.ids();
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/registry/ConfiguredPowers.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/ConfiguredPowers.java
@@ -1,0 +1,26 @@
+package io.github.apace100.origins.common.registry;
+
+import io.github.apace100.origins.common.power.ConfiguredPower;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Map;
+import java.util.Optional;
+
+public final class ConfiguredPowers {
+    private static final ConfiguredRegistry<ConfiguredPower> POWERS = new ConfiguredRegistry<>();
+
+    private ConfiguredPowers() {
+    }
+
+    public static void setAll(Map<ResourceLocation, ConfiguredPower> powers) {
+        POWERS.setAll(powers);
+    }
+
+    public static Optional<ConfiguredPower> get(ResourceLocation id) {
+        return POWERS.get(id);
+    }
+
+    public static Iterable<ResourceLocation> ids() {
+        return POWERS.ids();
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/registry/ConfiguredRegistry.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/ConfiguredRegistry.java
@@ -1,0 +1,39 @@
+package io.github.apace100.origins.common.registry;
+
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+/**
+ * Simple thread-safe registry used for configured datapack content that is resolved via codecs.
+ */
+public final class ConfiguredRegistry<T> {
+    private final Map<ResourceLocation, T> values = new ConcurrentHashMap<>();
+
+    public void setAll(Map<ResourceLocation, T> newValues) {
+        values.clear();
+        values.putAll(newValues);
+    }
+
+    public Optional<T> get(ResourceLocation id) {
+        return Optional.ofNullable(values.get(id));
+    }
+
+    public Collection<T> values() {
+        return Collections.unmodifiableCollection(values.values());
+    }
+
+    public Set<ResourceLocation> ids() {
+        return Collections.unmodifiableSet(values.keySet());
+    }
+
+    public Stream<Map.Entry<ResourceLocation, T>> stream() {
+        return values.entrySet().stream();
+    }
+}

--- a/src/main/java/io/github/apace100/origins/common/registry/ModItems.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/ModItems.java
@@ -3,6 +3,7 @@ package io.github.apace100.origins.common.registry;
 import io.github.apace100.origins.Origins;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.item.BlockItem;
+import io.github.apace100.origins.common.item.OrbOfOriginItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Rarity;
 import net.neoforged.neoforge.registries.DeferredHolder;
@@ -19,7 +20,7 @@ public final class ModItems {
 
     public static final DeferredHolder<Item, Item> ORB_OF_ORIGIN = ITEMS.register(
         "orb_of_origin",
-        () -> new Item(new Item.Properties().stacksTo(1).rarity(Rarity.UNCOMMON))
+        () -> new OrbOfOriginItem(new Item.Properties().stacksTo(1).rarity(Rarity.UNCOMMON))
     );
 
     private ModItems() {

--- a/src/main/java/io/github/apace100/origins/common/registry/ModPowers.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/ModPowers.java
@@ -1,11 +1,17 @@
 package io.github.apace100.origins.common.registry;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.common.registry.ModConditions;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentSerialization;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.List;
 
 public final class ModPowers {
     public static final ResourceLocation REGISTRY_NAME = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "powers");
@@ -22,8 +28,19 @@ public final class ModPowers {
         POWERS.register(modBus);
     }
 
-    public record PlaceholderPower() {
-        private static final Codec<PlaceholderPower> CODEC = Codec.unit(new PlaceholderPower());
+    public record PlaceholderPower(
+        Component name,
+        Component description,
+        java.util.List<ResourceLocation> actions,
+        ResourceLocation condition
+    ) {
+        private static final Codec<PlaceholderPower> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            ComponentSerialization.CODEC.fieldOf("name").forGetter(PlaceholderPower::name),
+            ComponentSerialization.CODEC.fieldOf("description").forGetter(PlaceholderPower::description),
+            ResourceLocation.CODEC.listOf().optionalFieldOf("actions", List.of()).forGetter(PlaceholderPower::actions),
+            ResourceLocation.CODEC.optionalFieldOf("condition", ModConditions.ALWAYS_TRUE.getId())
+                .forGetter(PlaceholderPower::condition)
+        ).apply(instance, PlaceholderPower::new));
 
         public static Codec<PlaceholderPower> codec() {
             return CODEC;

--- a/src/main/java/io/github/apace100/origins/common/registry/OriginRegistry.java
+++ b/src/main/java/io/github/apace100/origins/common/registry/OriginRegistry.java
@@ -1,0 +1,31 @@
+package io.github.apace100.origins.common.registry;
+
+import io.github.apace100.origins.common.origin.Origin;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+public final class OriginRegistry {
+    private static final ConfiguredRegistry<Origin> ORIGINS = new ConfiguredRegistry<>();
+
+    private OriginRegistry() {
+    }
+
+    public static void setAll(Map<ResourceLocation, Origin> origins) {
+        ORIGINS.setAll(origins);
+    }
+
+    public static Optional<Origin> get(ResourceLocation id) {
+        return ORIGINS.get(id);
+    }
+
+    public static Collection<ResourceLocation> ids() {
+        return ORIGINS.ids();
+    }
+
+    public static Collection<Origin> values() {
+        return ORIGINS.values();
+    }
+}

--- a/src/main/java/io/github/apace100/origins/datagen/OriginsLanguageProvider.java
+++ b/src/main/java/io/github/apace100/origins/datagen/OriginsLanguageProvider.java
@@ -16,5 +16,23 @@ public class OriginsLanguageProvider extends LanguageProvider {
     protected void addTranslations() {
         add(ModBlocks.ORIGIN_STONE.get(), "Origin Stone");
         add(ModItems.ORB_OF_ORIGIN.get(), "Orb of Origin");
+
+        add("commands.origins.reload_soon", "Reload scheduled - datapack changes will apply soon.");
+        add("commands.origins.list.empty", "No origins are currently registered.");
+        add("commands.origins.list.header", "Available origins: %s");
+        add("commands.origins.list.entry", "%s (%s) - %s powers");
+        add("commands.origins.set", "Set %s's origin to %s");
+        add("commands.origins.reset", "Cleared origin for %s");
+        add("commands.origins.error.unknown", "Unknown origin: %s");
+
+        add("screen.origins.select_origin", "Choose Your Origin");
+        add("screen.origins.origin", "Origin");
+        add("screen.origins.confirm", "Confirm");
+        add("screen.origins.reset", "Reset Origin");
+        add("screen.origins.none", "No Origin");
+        add("screen.origins.no_selection", "No origin selected");
+
+        add("key.categories.origins", "Origins");
+        add("key.origins.open_selection", "Open Origin Selection");
     }
 }

--- a/src/main/java/io/github/apace100/origins/neoforge/OriginsNeoForge.java
+++ b/src/main/java/io/github/apace100/origins/neoforge/OriginsNeoForge.java
@@ -1,6 +1,7 @@
 package io.github.apace100.origins.neoforge;
 
 import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.client.OriginsClient;
 import io.github.apace100.origins.common.config.ModConfigs;
 import io.github.apace100.origins.common.network.ModNetworking;
 import io.github.apace100.origins.common.registry.ModActions;
@@ -16,6 +17,8 @@ import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import net.neoforged.fml.ModLoadingContext;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.DistExecutor;
+import net.neoforged.api.distmarker.Dist;
 
 @Mod(Origins.MOD_ID)
 public final class OriginsNeoForge {
@@ -33,6 +36,8 @@ public final class OriginsNeoForge {
         ModDataGen.register(modEventBus);
 
         modEventBus.addListener(this::registerCapabilities);
+
+        DistExecutor.safeRunWhenOn(Dist.CLIENT, () -> OriginsClient::init);
 
     }
 

--- a/src/main/java/io/github/apace100/origins/neoforge/capability/PlayerOrigin.java
+++ b/src/main/java/io/github/apace100/origins/neoforge/capability/PlayerOrigin.java
@@ -33,6 +33,11 @@ public class PlayerOrigin {
         return powers;
     }
 
+    public void setPowers(Set<ResourceLocation> newPowers) {
+        powers.clear();
+        powers.addAll(newPowers);
+    }
+
     public CompoundTag saveNBT() {
         CompoundTag tag = new CompoundTag();
         if (originId != null) {

--- a/src/main/resources/data/origins/actions/test/noop.json
+++ b/src/main/resources/data/origins/actions/test/noop.json
@@ -1,0 +1,3 @@
+{
+  "type": "origins:noop"
+}

--- a/src/main/resources/data/origins/conditions/test/always_true.json
+++ b/src/main/resources/data/origins/conditions/test/always_true.json
@@ -1,0 +1,3 @@
+{
+  "type": "origins:always_true"
+}

--- a/src/main/resources/data/origins/origins/test_origin.json
+++ b/src/main/resources/data/origins/origins/test_origin.json
@@ -1,0 +1,11 @@
+{
+  "name": {
+    "text": "Test Origin"
+  },
+  "description": {
+    "text": "A placeholder origin used for integration testing."
+  },
+  "powers": [
+    "origins:test/test_power"
+  ]
+}

--- a/src/main/resources/data/origins/powers/test/test_power.json
+++ b/src/main/resources/data/origins/powers/test/test_power.json
@@ -1,0 +1,13 @@
+{
+  "type": "origins:placeholder",
+  "name": {
+    "text": "Test Power"
+  },
+  "description": {
+    "text": "A datapack power for validation."
+  },
+  "actions": [
+    "origins:test/noop"
+  ],
+  "condition": "origins:test/always_true"
+}


### PR DESCRIPTION
## Summary
- add configurable registries and reload listeners for actions, conditions, powers, and origins
- implement origin syncing packets, capability persistence, and admin commands for assigning origins
- introduce Orb of Origin GUI workflow with client keybind/config scaffolding and sample datapack content

## Testing
- ./gradlew --console=plain compileJava *(fails: missing neoForm merged jar in environment)*
- ./gradlew --console=plain clean compileJava *(fails: missing neoForm merged jar in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc684b3a388327b86709c63a2787e3