### PR TITLE
Add default Origins datapack support

### DIFF
--- a/src/main/java/io/github/apace100/origins/OriginsNeoForge.java
+++ b/src/main/java/io/github/apace100/origins/OriginsNeoForge.java
@@ -7,6 +7,7 @@ import io.github.apace100.origins.common.registry.ModActions;
 import io.github.apace100.origins.common.registry.ModConditions;
 import io.github.apace100.origins.common.registry.ModPowers;
 import io.github.apace100.origins.datagen.ModDataGen;
+import io.github.apace100.origins.neoforge.datapack.OriginsDataLoader;
 import io.github.apace100.origins.registry.ModBlocks;
 import io.github.apace100.origins.registry.ModItems;
 import net.neoforged.api.distmarker.Dist;
@@ -14,6 +15,8 @@ import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModLoadingContext;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.AddReloadListenerEvent;
 
 @Mod(OriginsNeoForge.MODID)
 public final class OriginsNeoForge {
@@ -30,6 +33,9 @@ public final class OriginsNeoForge {
         ModDataGen.register(modBus);
 
         ModConfigs.register(ModLoadingContext.get());
+
+        NeoForge.EVENT_BUS.addListener((AddReloadListenerEvent event) ->
+            event.addListener(new OriginsDataLoader()));
 
         if (FMLEnvironment.dist == Dist.CLIENT) {
             io.github.apace100.origins.client.OriginsClient.init();

--- a/src/main/java/io/github/apace100/origins/common/data/OriginsDataReloaders.java
+++ b/src/main/java/io/github/apace100/origins/common/data/OriginsDataReloaders.java
@@ -9,8 +9,6 @@ import net.neoforged.neoforge.event.AddReloadListenerEvent;
 public final class OriginsDataReloaders {
     private static final ConfiguredActionLoader ACTION_LOADER = new ConfiguredActionLoader();
     private static final ConfiguredConditionLoader CONDITION_LOADER = new ConfiguredConditionLoader();
-    private static final ConfiguredPowerLoader POWER_LOADER = new ConfiguredPowerLoader();
-    private static final OriginLoader ORIGIN_LOADER = new OriginLoader();
 
     private OriginsDataReloaders() {
     }
@@ -19,7 +17,5 @@ public final class OriginsDataReloaders {
     public static void onAddReloadListeners(AddReloadListenerEvent event) {
         event.addListener(ACTION_LOADER);
         event.addListener(CONDITION_LOADER);
-        event.addListener(POWER_LOADER);
-        event.addListener(ORIGIN_LOADER);
     }
 }

--- a/src/main/java/io/github/apace100/origins/neoforge/capability/PlayerOrigin.java
+++ b/src/main/java/io/github/apace100/origins/neoforge/capability/PlayerOrigin.java
@@ -1,5 +1,8 @@
 package io.github.apace100.origins.neoforge.capability;
 
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.common.registry.ConfiguredPowers;
+import io.github.apace100.origins.common.registry.OriginRegistry;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
@@ -72,8 +75,10 @@ public class PlayerOrigin {
         originId = null;
         if (tag.contains(NBT_ORIGIN, Tag.TAG_STRING)) {
             ResourceLocation parsed = ResourceLocation.tryParse(tag.getString(NBT_ORIGIN));
-            if (parsed != null) {
+            if (parsed != null && OriginRegistry.get(parsed).isPresent()) {
                 originId = parsed;
+            } else if (parsed != null) {
+                Origins.LOGGER.warn("Dropping unknown origin {} from player capability data", parsed);
             }
         }
 
@@ -82,8 +87,10 @@ public class PlayerOrigin {
             ListTag list = tag.getList(NBT_POWERS, Tag.TAG_STRING);
             for (int i = 0; i < list.size(); i++) {
                 ResourceLocation parsedPower = ResourceLocation.tryParse(list.getString(i));
-                if (parsedPower != null) {
+                if (parsedPower != null && ConfiguredPowers.get(parsedPower).isPresent()) {
                     powers.add(parsedPower);
+                } else if (parsedPower != null) {
+                    Origins.LOGGER.warn("Skipping unknown power {} from player capability data", parsedPower);
                 }
             }
         }

--- a/src/main/java/io/github/apace100/origins/neoforge/datapack/OriginsDataLoader.java
+++ b/src/main/java/io/github/apace100/origins/neoforge/datapack/OriginsDataLoader.java
@@ -1,0 +1,181 @@
+package io.github.apace100.origins.neoforge.datapack;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.JsonOps;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.common.origin.Origin;
+import io.github.apace100.origins.common.power.ConfiguredPower;
+import io.github.apace100.origins.common.registry.ConfiguredActions;
+import io.github.apace100.origins.common.registry.ConfiguredConditions;
+import io.github.apace100.origins.common.registry.ConfiguredPowers;
+import io.github.apace100.origins.common.registry.ModPowers;
+import io.github.apace100.origins.common.registry.OriginRegistry;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentSerialization;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.neoforged.neoforge.registries.DeferredHolder;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Combined reload listener that reads the default Origins datapack structure
+ * (powers and origins) and feeds the decoded data into the runtime registries.
+ */
+public final class OriginsDataLoader extends SimpleJsonResourceReloadListener {
+    private static final Gson GSON = new GsonBuilder().setLenient().create();
+    private static final Codec<OriginData> ORIGIN_CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        ComponentSerialization.CODEC.fieldOf("name").forGetter(OriginData::name),
+        ComponentSerialization.CODEC.fieldOf("description").forGetter(OriginData::description),
+        ResourceLocation.CODEC.listOf().optionalFieldOf("powers", List.of()).forGetter(OriginData::powers)
+    ).apply(instance, OriginData::new));
+    private static final JsonGatherer POWER_GATHERER = new JsonGatherer("origins/powers");
+
+    private Map<ResourceLocation, JsonElement> pendingPowerJson = Map.of();
+
+    public OriginsDataLoader() {
+        super(GSON, "origins/origins");
+    }
+
+    @Override
+    protected Map<ResourceLocation, JsonElement> prepare(ResourceManager resourceManager, ProfilerFiller profiler) {
+        pendingPowerJson = POWER_GATHERER.gather(resourceManager, profiler);
+        return super.prepare(resourceManager, profiler);
+    }
+
+    @Override
+    protected void apply(Map<ResourceLocation, JsonElement> originJson, ResourceManager resourceManager, ProfilerFiller profiler) {
+        Map<ResourceLocation, ConfiguredPower> powers = decodePowers(pendingPowerJson);
+        ConfiguredPowers.setAll(powers);
+
+        Map<ResourceLocation, Origin> origins = decodeOrigins(originJson);
+        OriginRegistry.setAll(origins);
+
+        Origins.LOGGER.info("Loaded {} origins and {} powers from datapacks", origins.size(), powers.size());
+    }
+
+    private Map<ResourceLocation, ConfiguredPower> decodePowers(Map<ResourceLocation, JsonElement> powerJson) {
+        Map<ResourceLocation, ConfiguredPower> decoded = new HashMap<>();
+        powerJson.forEach((id, element) -> decodePower(id, element)
+            .ifPresent(power -> decoded.put(id, validatePower(id, power))));
+        return decoded;
+    }
+
+    private Optional<ConfiguredPower> decodePower(ResourceLocation id, JsonElement element) {
+        JsonObject json = GsonHelper.convertToJsonObject(element, "value");
+        ResourceLocation typeId;
+        try {
+            typeId = ResourceLocation.parse(GsonHelper.getAsString(json, "type"));
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.error("Failed to parse power {}: {}", id, exception.getMessage());
+            return Optional.empty();
+        }
+
+        Codec<? extends ConfiguredPower> codec = resolveCodec(typeId);
+        if (codec == null) {
+            Origins.LOGGER.warn("Unknown power type '{}' for data file '{}'", typeId, id);
+            return Optional.empty();
+        }
+
+        DataResult<? extends ConfiguredPower> result = codec.parse(JsonOps.INSTANCE, json);
+        return result.resultOrPartial(message -> Origins.LOGGER.error("Failed to decode power {}: {}", id, message))
+            .map(ConfiguredPower.class::cast);
+    }
+
+    private ConfiguredPower validatePower(ResourceLocation id, ConfiguredPower power) {
+        List<ResourceLocation> actions = power.actions().stream().filter(actionId -> {
+            boolean present = ConfiguredActions.get(actionId).isPresent();
+            if (!present) {
+                Origins.LOGGER.warn("Power {} references unknown action {}", id, actionId);
+            }
+            return present;
+        }).toList();
+
+        if (ConfiguredConditions.get(power.condition()).isEmpty()) {
+            Origins.LOGGER.warn("Power {} references unknown condition {}", id, power.condition());
+        }
+
+        return new ConfiguredPower(power.type(), power.name(), power.description(), actions, power.condition());
+    }
+
+    private Map<ResourceLocation, Origin> decodeOrigins(Map<ResourceLocation, JsonElement> originJson) {
+        Map<ResourceLocation, Origin> decoded = new HashMap<>();
+        originJson.forEach((id, element) -> decodeOrigin(id, element)
+            .resultOrPartial(message -> Origins.LOGGER.error("Failed to decode origin {}: {}", id, message))
+            .ifPresent(origin -> decoded.put(id, validateOrigin(id, origin))));
+        return decoded;
+    }
+
+    private DataResult<Origin> decodeOrigin(ResourceLocation id, JsonElement element) {
+        return ORIGIN_CODEC.parse(JsonOps.INSTANCE, element)
+            .map(data -> new Origin(id, data.name(), data.description(), new ArrayList<>(data.powers())));
+    }
+
+    private Origin validateOrigin(ResourceLocation id, Origin origin) {
+        List<ResourceLocation> powers = origin.powers().stream().filter(powerId -> {
+            boolean present = ConfiguredPowers.get(powerId).isPresent();
+            if (!present) {
+                Origins.LOGGER.warn("Origin {} references unknown power {}", id, powerId);
+            }
+            return present;
+        }).collect(Collectors.toList());
+        return new Origin(origin.id(), origin.name(), origin.description(), powers);
+    }
+
+    private Codec<? extends ConfiguredPower> resolveCodec(ResourceLocation typeId) {
+        Codec<ModPowers.PlaceholderPower> codec = findCodec(typeId);
+        if (codec == null) {
+            return null;
+        }
+
+        return codec.xmap(power -> new ConfiguredPower(typeId, power.name(), power.description(), power.actions(), power.condition()),
+            configured -> new ModPowers.PlaceholderPower(
+                configured.name(),
+                configured.description(),
+                List.copyOf(configured.actions()),
+                configured.condition()
+            ));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Codec<ModPowers.PlaceholderPower> findCodec(ResourceLocation typeId) {
+        for (DeferredHolder<Codec<?>, ? extends Codec<?>> holder : ModPowers.POWERS.getEntries()) {
+            if (holder.getId().equals(typeId)) {
+                return (Codec<ModPowers.PlaceholderPower>) holder.get();
+            }
+        }
+        return null;
+    }
+
+    private record OriginData(Component name, Component description, List<ResourceLocation> powers) {
+    }
+
+    private static final class JsonGatherer extends SimpleJsonResourceReloadListener {
+        JsonGatherer(String directory) {
+            super(GSON, directory);
+        }
+
+        Map<ResourceLocation, JsonElement> gather(ResourceManager resourceManager, ProfilerFiller profiler) {
+            return super.prepare(resourceManager, profiler);
+        }
+
+        @Override
+        protected void apply(Map<ResourceLocation, JsonElement> object, ResourceManager resourceManager, ProfilerFiller profiler) {
+            // no-op, this helper only exposes the protected prepare method
+        }
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/Power.java
+++ b/src/main/java/io/github/apace100/origins/power/Power.java
@@ -1,0 +1,27 @@
+package io.github.apace100.origins.power;
+
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * Base class for gameplay powers. Concrete implementations should override
+ * {@link #tick(Player)} and other lifecycle hooks once full gameplay logic is
+ * implemented.
+ */
+public abstract class Power {
+    private final PowerType<?> type;
+
+    protected Power(PowerType<?> type) {
+        this.type = type;
+    }
+
+    public PowerType<?> getType() {
+        return type;
+    }
+
+    /**
+     * Called every tick while the power is active on a player.
+     */
+    public void tick(Player player) {
+        // Default no-op
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/PowerType.java
+++ b/src/main/java/io/github/apace100/origins/power/PowerType.java
@@ -1,0 +1,19 @@
+package io.github.apace100.origins.power;
+
+import net.minecraft.resources.ResourceLocation;
+
+/**
+ * Minimal placeholder for data-driven power types. The full logic will be
+ * implemented in later milestones.
+ */
+public class PowerType<T extends Power> {
+    private final ResourceLocation id;
+
+    public PowerType(ResourceLocation id) {
+        this.id = id;
+    }
+
+    public ResourceLocation id() {
+        return id;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/AquaticPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/AquaticPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class AquaticPower extends Power {
+    public AquaticPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Allow Merlings to breathe underwater
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/BurningWrathPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/BurningWrathPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class BurningWrathPower extends Power {
+    public BurningWrathPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Boost damage while the user is burning
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/CatlikeReflexesPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/CatlikeReflexesPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class CatlikeReflexesPower extends Power {
+    public CatlikeReflexesPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Negate fall damage for feline players
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/ClaustrophobiaPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/ClaustrophobiaPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class ClaustrophobiaPower extends Power {
+    public ClaustrophobiaPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Handle Elytrian penalties in tight spaces
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/CreeperRepellentPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/CreeperRepellentPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class CreeperRepellentPower extends Power {
+    public CreeperRepellentPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Cause creepers to flee from feline players
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/ElytraFlightPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/ElytraFlightPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class ElytraFlightPower extends Power {
+    public ElytraFlightPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Implement Elytrian flight mechanics
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/EnderStepPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/EnderStepPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class EnderStepPower extends Power {
+    public EnderStepPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Teleport the player using an ability-based pearl
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/FeatherweightPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/FeatherweightPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class FeatherweightPower extends Power {
+    public FeatherweightPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Apply slow falling-style mechanics to Avians
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/FireImmunityPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/FireImmunityPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class FireImmunityPower extends Power {
+    public FireImmunityPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Prevent fire and lava damage for Blazeborn
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/FreshAirPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/FreshAirPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class FreshAirPower extends Power {
+    public FreshAirPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Prevent Avians from sleeping underground
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/HeavyStonePower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/HeavyStonePower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class HeavyStonePower extends Power {
+    public HeavyStonePower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Apply movement penalties due to heavy skin
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/LaunchIntoAirPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/LaunchIntoAirPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class LaunchIntoAirPower extends Power {
+    public LaunchIntoAirPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Implement Elytrian launch ability
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/NetherSpawnPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/NetherSpawnPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class NetherSpawnPower extends Power {
+    public NetherSpawnPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Spawn the player in the Nether dimension
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/PhantomHungerPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/PhantomHungerPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class PhantomHungerPower extends Power {
+    public PhantomHungerPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Increase hunger drain in sunlight
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/PhantomInvisibilityPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/PhantomInvisibilityPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class PhantomInvisibilityPower extends Power {
+    public PhantomInvisibilityPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Hide Phantoms while phased
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/PhasePower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/PhasePower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class PhasePower extends Power {
+    public PhasePower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Let Phantoms switch between physical and ghost form
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/PumpkinAllergyPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/PumpkinAllergyPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class PumpkinAllergyPower extends Power {
+    public PumpkinAllergyPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Block vision when wearing carved pumpkins
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/ShulkerInventoryPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/ShulkerInventoryPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class ShulkerInventoryPower extends Power {
+    public ShulkerInventoryPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Provide access to the Shulk extra inventory
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/StoneSkinPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/StoneSkinPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class StoneSkinPower extends Power {
+    public StoneSkinPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Grant natural armor to Shulk players
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/SwimSpeedPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/SwimSpeedPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class SwimSpeedPower extends Power {
+    public SwimSpeedPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Increase swimming speed while in water
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/TailwindPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/TailwindPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class TailwindPower extends Power {
+    public TailwindPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Provide a sprinting speed boost
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/UnderwaterVisionPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/UnderwaterVisionPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class UnderwaterVisionPower extends Power {
+    public UnderwaterVisionPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Improve visibility for underwater Merlings
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/WaterVulnerabilityPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/WaterVulnerabilityPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class WaterVulnerabilityPower extends Power {
+    public WaterVulnerabilityPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Damage Enderian players when wet
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/impl/WeakArmsPower.java
+++ b/src/main/java/io/github/apace100/origins/power/impl/WeakArmsPower.java
@@ -1,0 +1,16 @@
+package io.github.apace100.origins.power.impl;
+
+import io.github.apace100.origins.power.Power;
+import io.github.apace100.origins.power.PowerType;
+import net.minecraft.world.entity.player.Player;
+
+public class WeakArmsPower extends Power {
+    public WeakArmsPower(PowerType<?> type) {
+        super(type);
+    }
+
+    @Override
+    public void tick(Player player) {
+        // TODO: Restrict mining stone without appropriate tools
+    }
+}

--- a/src/main/resources/data/origins/layers/origin.json
+++ b/src/main/resources/data/origins/layers/origin.json
@@ -1,0 +1,15 @@
+{
+  "order": 0,
+  "replace": false,
+  "origins": [
+    "origins:human",
+    "origins:elytrian",
+    "origins:feline",
+    "origins:shulk",
+    "origins:enderian",
+    "origins:avian",
+    "origins:merling",
+    "origins:phantom",
+    "origins:blazeborn"
+  ]
+}

--- a/src/main/resources/data/origins/origins/avian.json
+++ b/src/main/resources/data/origins/origins/avian.json
@@ -1,0 +1,11 @@
+{
+  "name": { "text": "Avian" },
+  "description": { "text": "Lightweight and free-spirited, Avians glide through life." },
+  "powers": [
+    "origins:slow_falling",
+    "origins:fresh_air",
+    "origins:tailwind"
+  ],
+  "icon": "minecraft:feather",
+  "impact": 1
+}

--- a/src/main/resources/data/origins/origins/blazeborn.json
+++ b/src/main/resources/data/origins/origins/blazeborn.json
@@ -1,0 +1,11 @@
+{
+  "name": { "text": "Blazeborn" },
+  "description": { "text": "Blazeborn thrive in scorching environments but find water unbearable." },
+  "powers": [
+    "origins:fire_immunity",
+    "origins:burning_wrath",
+    "origins:nether_spawn"
+  ],
+  "icon": "minecraft:blaze_powder",
+  "impact": 3
+}

--- a/src/main/resources/data/origins/origins/elytrian.json
+++ b/src/main/resources/data/origins/origins/elytrian.json
@@ -1,0 +1,11 @@
+{
+  "name": { "text": "Elytrian" },
+  "description": { "text": "Born with the gift of wings, Elytrians excel in the skies but struggle in tight spaces." },
+  "powers": [
+    "origins:elytra_flight",
+    "origins:launch_into_air",
+    "origins:claustrophobia"
+  ],
+  "icon": "minecraft:elytra",
+  "impact": 3
+}

--- a/src/main/resources/data/origins/origins/enderian.json
+++ b/src/main/resources/data/origins/origins/enderian.json
@@ -1,0 +1,11 @@
+{
+  "name": { "text": "Enderian" },
+  "description": { "text": "Enderfolk who blink through space but dislike water and pumpkins." },
+  "powers": [
+    "origins:throw_pearl",
+    "origins:water_vulnerability",
+    "origins:pumpkin_hate"
+  ],
+  "icon": "minecraft:ender_pearl",
+  "impact": 2
+}

--- a/src/main/resources/data/origins/origins/feline.json
+++ b/src/main/resources/data/origins/origins/feline.json
@@ -1,0 +1,11 @@
+{
+  "name": { "text": "Feline" },
+  "description": { "text": "Catlike agility and skittish energy define the Feline." },
+  "powers": [
+    "origins:cat_fall_immunity",
+    "origins:scare_creepers",
+    "origins:weak_arms"
+  ],
+  "icon": "minecraft:cod",
+  "impact": 1
+}

--- a/src/main/resources/data/origins/origins/human.json
+++ b/src/main/resources/data/origins/origins/human.json
@@ -1,0 +1,7 @@
+{
+  "name": { "text": "Human" },
+  "description": { "text": "A regular inhabitant of the Overworld without any unique traits." },
+  "powers": [],
+  "icon": "minecraft:player_head",
+  "impact": 0
+}

--- a/src/main/resources/data/origins/origins/merling.json
+++ b/src/main/resources/data/origins/origins/merling.json
@@ -1,0 +1,11 @@
+{
+  "name": { "text": "Merling" },
+  "description": { "text": "Merlings are at home in the water but struggle on land." },
+  "powers": [
+    "origins:water_breathing",
+    "origins:underwater_vision",
+    "origins:swim_speed"
+  ],
+  "icon": "minecraft:trident",
+  "impact": 2
+}

--- a/src/main/resources/data/origins/origins/phantom.json
+++ b/src/main/resources/data/origins/origins/phantom.json
@@ -1,0 +1,11 @@
+{
+  "name": { "text": "Phantom" },
+  "description": { "text": "Phantoms fade between worlds, gaining mobility but losing hunger in the light." },
+  "powers": [
+    "origins:phantomize",
+    "origins:phantom_invisibility",
+    "origins:phantom_hunger"
+  ],
+  "icon": "minecraft:phantom_membrane",
+  "impact": 2
+}

--- a/src/main/resources/data/origins/origins/shulk.json
+++ b/src/main/resources/data/origins/origins/shulk.json
@@ -1,0 +1,11 @@
+{
+  "name": { "text": "Shulk" },
+  "description": { "text": "Sturdy and storage-savvy, Shulks carry their home wherever they go." },
+  "powers": [
+    "origins:shulk_inventory",
+    "origins:shulk_stone_skin",
+    "origins:shulk_heavy_stone"
+  ],
+  "icon": "minecraft:shulker_shell",
+  "impact": 2
+}

--- a/src/main/resources/data/origins/powers/burning_wrath.json
+++ b/src/main/resources/data/origins/powers/burning_wrath.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Burning Wrath" },
+  "description": { "text": "While on fire your attacks grow stronger." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/cat_fall_immunity.json
+++ b/src/main/resources/data/origins/powers/cat_fall_immunity.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Catlike Reflexes" },
+  "description": { "text": "You land on your feet, negating fall damage." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/claustrophobia.json
+++ b/src/main/resources/data/origins/powers/claustrophobia.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Claustrophobia" },
+  "description": { "text": "Being in confined spaces weakens you." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/elytra_flight.json
+++ b/src/main/resources/data/origins/powers/elytra_flight.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Winged" },
+  "description": { "text": "Your wings allow you to glide naturally without needing an elytra item." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/fire_immunity.json
+++ b/src/main/resources/data/origins/powers/fire_immunity.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Fire Immunity" },
+  "description": { "text": "Lava and fire cannot harm you." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/fresh_air.json
+++ b/src/main/resources/data/origins/powers/fresh_air.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Fresh Air" },
+  "description": { "text": "You cannot sleep below the surface." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/launch_into_air.json
+++ b/src/main/resources/data/origins/powers/launch_into_air.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Gift of the Winds" },
+  "description": { "text": "Propel yourself into the air every now and then to gain altitude." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/nether_spawn.json
+++ b/src/main/resources/data/origins/powers/nether_spawn.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Nether Spawn" },
+  "description": { "text": "You spawn in the Nether and feel at home there." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/phantom_hunger.json
+++ b/src/main/resources/data/origins/powers/phantom_hunger.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Restless Hunger" },
+  "description": { "text": "You exhaust more quickly while exposed to sunlight." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/phantom_invisibility.json
+++ b/src/main/resources/data/origins/powers/phantom_invisibility.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Translucent" },
+  "description": { "text": "You become invisible while in phantom form." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/phantomize.json
+++ b/src/main/resources/data/origins/powers/phantomize.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Phase" },
+  "description": { "text": "Shift between material and phantom form at will." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/pumpkin_hate.json
+++ b/src/main/resources/data/origins/powers/pumpkin_hate.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Pumpkin Allergy" },
+  "description": { "text": "Wearing pumpkins obscures your vision entirely." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/scare_creepers.json
+++ b/src/main/resources/data/origins/powers/scare_creepers.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Nine Lives" },
+  "description": { "text": "Creepers are scared of you and will flee instead of exploding." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/shulk_heavy_stone.json
+++ b/src/main/resources/data/origins/powers/shulk_heavy_stone.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Heavy Stone" },
+  "description": { "text": "Your dense skin makes swimming and using shields harder." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/shulk_inventory.json
+++ b/src/main/resources/data/origins/powers/shulk_inventory.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Shulker Storage" },
+  "description": { "text": "You keep a special inventory accessible anywhere." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/shulk_stone_skin.json
+++ b/src/main/resources/data/origins/powers/shulk_stone_skin.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Stone Skin" },
+  "description": { "text": "Your natural armor protects you without the need for gear." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/slow_falling.json
+++ b/src/main/resources/data/origins/powers/slow_falling.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Featherweight" },
+  "description": { "text": "You fall gently, taking little to no fall damage." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/swim_speed.json
+++ b/src/main/resources/data/origins/powers/swim_speed.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Swift Swimmer" },
+  "description": { "text": "You move faster while swimming." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/tailwind.json
+++ b/src/main/resources/data/origins/powers/tailwind.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Tailwind" },
+  "description": { "text": "You move a little faster while sprinting." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/throw_pearl.json
+++ b/src/main/resources/data/origins/powers/throw_pearl.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Ender Step" },
+  "description": { "text": "You can throw a ghostly pearl that teleports you on demand." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/underwater_vision.json
+++ b/src/main/resources/data/origins/powers/underwater_vision.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Clear Waters" },
+  "description": { "text": "You see clearly underwater." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/water_breathing.json
+++ b/src/main/resources/data/origins/powers/water_breathing.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Aquatic" },
+  "description": { "text": "You can breathe indefinitely while underwater." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/water_vulnerability.json
+++ b/src/main/resources/data/origins/powers/water_vulnerability.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Hydrophobia" },
+  "description": { "text": "Water damages you as if you were an Enderman." },
+  "actions": []
+}

--- a/src/main/resources/data/origins/powers/weak_arms.json
+++ b/src/main/resources/data/origins/powers/weak_arms.json
@@ -1,0 +1,6 @@
+{
+  "type": "origins:placeholder",
+  "name": { "text": "Weak Arms" },
+  "description": { "text": "You cannot mine natural stone without the use of a tool." },
+  "actions": []
+}


### PR DESCRIPTION
## Summary
- add datapack JSON definitions for the default Origins layer, origins, and powers
- implement a combined datapack reload listener that hydrates the runtime registries and validates saved capability data
- scaffold base and placeholder power classes for future gameplay logic

## Testing
- `./gradlew compileJava`


------
https://chatgpt.com/codex/tasks/task_e_68dd43b1a1208327b01848f4e179f0f9