### PR TITLE
Scaffold action and condition stubs for datapack parity

### DIFF
--- a/src/main/java/io/github/apace100/origins/datapack/DataValidationLogger.java
+++ b/src/main/java/io/github/apace100/origins/datapack/DataValidationLogger.java
@@ -18,7 +18,8 @@ public final class DataValidationLogger extends SimplePreparableReloadListener<V
     @Override
     protected void apply(Void value, ResourceManager resourceManager, ProfilerFiller profiler) {
         ReloadStats stats = OriginsDataLoader.getLastReloadStats();
-        Origins.LOGGER.info("[Origins] Datapack reload summary: {} origins, {} powers", stats.originsLoaded(), stats.powersLoaded());
+        Origins.LOGGER.info("[Origins] Datapack reload summary: {} origins, {} powers, {} actions, {} conditions",
+            stats.originsLoaded(), stats.powersLoaded(), stats.actionsLoaded(), stats.conditionsLoaded());
         if (stats.skippedEntries() > 0) {
             Origins.LOGGER.info("[Origins] Datapack skipped {} entries during reload", stats.skippedEntries());
         }
@@ -26,7 +27,7 @@ public final class DataValidationLogger extends SimplePreparableReloadListener<V
             String joined = stats.unknownTypes().stream()
                 .map(ResourceLocation::toString)
                 .collect(Collectors.joining(", "));
-            Origins.LOGGER.warn("[Origins] Datapack unknown power types: {}", joined);
+            Origins.LOGGER.warn("[Origins] Datapack unknown entry types: {}", joined);
         }
     }
 }

--- a/src/main/java/io/github/apace100/origins/datapack/OriginsDataLoader.java
+++ b/src/main/java/io/github/apace100/origins/datapack/OriginsDataLoader.java
@@ -18,6 +18,10 @@ import io.github.apace100.origins.common.registry.ConfiguredConditions;
 import io.github.apace100.origins.common.registry.ConfiguredPowers;
 import io.github.apace100.origins.common.registry.ModPowers;
 import io.github.apace100.origins.common.registry.OriginRegistry;
+import io.github.apace100.origins.power.action.Action;
+import io.github.apace100.origins.power.action.registry.ActionRegistry;
+import io.github.apace100.origins.power.condition.Condition;
+import io.github.apace100.origins.power.condition.registry.ConditionRegistry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.ComponentSerialization;
@@ -40,6 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Combined reload listener that reads the default Origins datapack structure
@@ -55,6 +60,8 @@ public final class OriginsDataLoader extends SimpleJsonResourceReloadListener {
         Codec.INT.optionalFieldOf("impact").forGetter(OriginData::impact)
     ).apply(instance, OriginData::new));
     private static final JsonGatherer POWER_GATHERER = new JsonGatherer("origins/powers");
+    private static final JsonGatherer ACTION_GATHERER = new JsonGatherer("origins/actions");
+    private static final JsonGatherer CONDITION_GATHERER = new JsonGatherer("origins/conditions");
     private static final Map<ResourceLocation, ResourceLocation> POWER_ALIASES = Map.of(
         ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "elytra"),
         ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "elytra_flight"),
@@ -64,9 +71,15 @@ public final class OriginsDataLoader extends SimpleJsonResourceReloadListener {
 
     private static volatile ReloadStats LAST_STATS = ReloadStats.empty();
 
+    private Map<ResourceLocation, JsonElement> pendingActionJson = Map.of();
+    private Map<ResourceLocation, JsonElement> pendingConditionJson = Map.of();
     private Map<ResourceLocation, JsonElement> pendingPowerJson = Map.of();
+    private int skippedActions;
+    private int skippedConditions;
     private int skippedPowers;
     private int skippedOrigins;
+    private final Set<ResourceLocation> unknownActionTypes = new HashSet<>();
+    private final Set<ResourceLocation> unknownConditionTypes = new HashSet<>();
     private final Set<ResourceLocation> unknownPowerTypes = new HashSet<>();
 
     public OriginsDataLoader() {
@@ -75,32 +88,100 @@ public final class OriginsDataLoader extends SimpleJsonResourceReloadListener {
 
     @Override
     protected Map<ResourceLocation, JsonElement> prepare(ResourceManager resourceManager, ProfilerFiller profiler) {
+        skippedActions = 0;
+        skippedConditions = 0;
         skippedPowers = 0;
         skippedOrigins = 0;
+        unknownActionTypes.clear();
+        unknownConditionTypes.clear();
         unknownPowerTypes.clear();
+        pendingActionJson = ACTION_GATHERER.gather(resourceManager, profiler);
+        pendingConditionJson = CONDITION_GATHERER.gather(resourceManager, profiler);
         pendingPowerJson = POWER_GATHERER.gather(resourceManager, profiler);
         return super.prepare(resourceManager, profiler);
     }
 
     @Override
     protected void apply(Map<ResourceLocation, JsonElement> originJson, ResourceManager resourceManager, ProfilerFiller profiler) {
+        ActionRegistry.bootstrap();
+        ConditionRegistry.bootstrap();
+
+        Map<ResourceLocation, Action<?>> actions = decodeActions(pendingActionJson);
+        ActionRegistry.setAll(actions);
+
+        Map<ResourceLocation, Condition<?>> conditions = decodeConditions(pendingConditionJson);
+        ConditionRegistry.setAll(conditions);
+
         Map<ResourceLocation, ConfiguredPower> powers = decodePowers(pendingPowerJson);
         ConfiguredPowers.setAll(powers);
 
         Map<ResourceLocation, Origin> origins = decodeOrigins(originJson);
         OriginRegistry.setAll(origins);
 
-        List<ResourceLocation> unknownTypes = unknownPowerTypes.stream()
+        List<ResourceLocation> unknownTypes = Stream.of(unknownPowerTypes, unknownActionTypes, unknownConditionTypes)
+            .flatMap(Set::stream)
             .sorted(Comparator.comparing(ResourceLocation::toString))
             .toList();
-        LAST_STATS = new ReloadStats(origins.size(), powers.size(), skippedOrigins + skippedPowers, unknownTypes);
+        int totalSkipped = skippedOrigins + skippedPowers + skippedActions + skippedConditions;
+        LAST_STATS = new ReloadStats(origins.size(), powers.size(), actions.size(), conditions.size(), totalSkipped, unknownTypes);
 
-        if (skippedOrigins + skippedPowers > 0) {
-            Origins.LOGGER.info("Loaded {} origins and {} powers from datapacks ({} entries skipped)",
-                origins.size(), powers.size(), skippedOrigins + skippedPowers);
+        if (totalSkipped > 0) {
+            Origins.LOGGER.info("Loaded {} origins, {} powers, {} actions, and {} conditions from datapacks ({} entries skipped)",
+                origins.size(), powers.size(), actions.size(), conditions.size(), totalSkipped);
         } else {
-            Origins.LOGGER.info("Loaded {} origins and {} powers from datapacks", origins.size(), powers.size());
+            Origins.LOGGER.info("Loaded {} origins, {} powers, {} actions, and {} conditions from datapacks",
+                origins.size(), powers.size(), actions.size(), conditions.size());
         }
+    }
+
+    private Map<ResourceLocation, Action<?>> decodeActions(Map<ResourceLocation, JsonElement> actionJson) {
+        Map<ResourceLocation, Action<?>> decoded = new HashMap<>();
+        actionJson.forEach((id, element) -> decodeAction(id, element).ifPresent(action -> decoded.put(id, action)));
+        return decoded;
+    }
+
+    private Optional<Action<?>> decodeAction(ResourceLocation id, JsonElement element) {
+        JsonObject json = GsonHelper.convertToJsonObject(element, "value");
+        ResourceLocation typeId = parseType(id, json, "action");
+        if (typeId == null) {
+            skippedActions++;
+            return Optional.empty();
+        }
+
+        Optional<Action<?>> action = ActionRegistry.create(typeId, id, json);
+        if (action.isEmpty()) {
+            Origins.LOGGER.warn("Unknown action type '{}' for data file '{}'", typeId, id);
+            unknownActionTypes.add(typeId);
+            skippedActions++;
+            return Optional.empty();
+        }
+
+        return action;
+    }
+
+    private Map<ResourceLocation, Condition<?>> decodeConditions(Map<ResourceLocation, JsonElement> conditionJson) {
+        Map<ResourceLocation, Condition<?>> decoded = new HashMap<>();
+        conditionJson.forEach((id, element) -> decodeCondition(id, element).ifPresent(condition -> decoded.put(id, condition)));
+        return decoded;
+    }
+
+    private Optional<Condition<?>> decodeCondition(ResourceLocation id, JsonElement element) {
+        JsonObject json = GsonHelper.convertToJsonObject(element, "value");
+        ResourceLocation typeId = parseType(id, json, "condition");
+        if (typeId == null) {
+            skippedConditions++;
+            return Optional.empty();
+        }
+
+        Optional<Condition<?>> condition = ConditionRegistry.create(typeId, id, json);
+        if (condition.isEmpty()) {
+            Origins.LOGGER.warn("Unknown condition type '{}' for data file '{}'", typeId, id);
+            unknownConditionTypes.add(typeId);
+            skippedConditions++;
+            return Optional.empty();
+        }
+
+        return condition;
     }
 
     private Map<ResourceLocation, ConfiguredPower> decodePowers(Map<ResourceLocation, JsonElement> powerJson) {
@@ -134,6 +215,31 @@ public final class OriginsDataLoader extends SimpleJsonResourceReloadListener {
             return Optional.empty();
         }
         return parsed.map(ConfiguredPower.class::cast);
+    }
+
+    private ResourceLocation parseType(ResourceLocation entryId, JsonObject json, String entryKind) {
+        String rawType = GsonHelper.getAsString(json, "type", "");
+        if (rawType.isEmpty()) {
+            Origins.LOGGER.warn("{} {} is missing a type entry", capitalize(entryKind), entryId);
+            return null;
+        }
+
+        try {
+            return ResourceLocation.parse(rawType);
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("{} {} has invalid type '{}': {}", capitalize(entryKind), entryId, rawType, exception.getMessage());
+            return null;
+        }
+    }
+
+    private static String capitalize(String value) {
+        if (value == null || value.isEmpty()) {
+            return "";
+        }
+        if (value.length() == 1) {
+            return value.toUpperCase();
+        }
+        return Character.toUpperCase(value.charAt(0)) + value.substring(1);
     }
 
     private ConfiguredPower validatePower(ResourceLocation id, ConfiguredPower power) {
@@ -346,11 +452,13 @@ public final class OriginsDataLoader extends SimpleJsonResourceReloadListener {
     public record ReloadStats(
         int originsLoaded,
         int powersLoaded,
+        int actionsLoaded,
+        int conditionsLoaded,
         int skippedEntries,
         List<ResourceLocation> unknownTypes
     ) {
         static ReloadStats empty() {
-            return new ReloadStats(0, 0, 0, List.of());
+            return new ReloadStats(0, 0, 0, 0, 0, List.of());
         }
     }
 

--- a/src/main/java/io/github/apace100/origins/power/action/Action.java
+++ b/src/main/java/io/github/apace100/origins/power/action/Action.java
@@ -1,0 +1,21 @@
+package io.github.apace100.origins.power.action;
+
+/**
+ * Placeholder contract for Origins datapack actions.
+ * <p>
+ * Actions will be hydrated from datapack JSON and executed later in the
+ * runtime once the supporting systems are implemented. Until then this
+ * interface provides a simple scaffold for the action stubs generated as
+ * part of the Fabric parity effort.
+ *
+ * @param <T> the context type supplied when running the action.
+ */
+@FunctionalInterface
+public interface Action<T> {
+    /**
+     * Executes the action against the provided context object.
+     *
+     * @param context the invocation context defined by the action type
+     */
+    void execute(T context);
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/BiEntityAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/BiEntityAction.java
@@ -1,0 +1,82 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.Entity;
+
+import java.util.Optional;
+
+/**
+ * Scaffold implementation for bi-entity datapack actions.
+ */
+public final class BiEntityAction implements Action<BiEntityAction.BiEntityContext> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "bi_entity");
+    private static final Codec<BiEntityAction> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.STRING.optionalFieldOf("relationship").forGetter(BiEntityAction::relationship)
+    ).apply(instance, relationship -> new BiEntityAction(relationship.map(Relationship::fromString))));
+
+    private final Optional<Relationship> relationship;
+
+    private BiEntityAction(Optional<Relationship> relationship) {
+        this.relationship = relationship;
+    }
+
+    public Optional<String> relationship() {
+        return relationship.map(Relationship::serializedName);
+    }
+
+    @Override
+    public void execute(BiEntityContext context) {
+        // TODO: Implement Fabric parity behaviour for bi-entity actions (attacker/target interactions).
+    }
+
+    public static BiEntityAction fromJson(ResourceLocation id, JsonObject json) {
+        Optional<Relationship> parsed = Optional.empty();
+        if (json.has("relationship")) {
+            String raw = GsonHelper.getAsString(json, "relationship");
+            Relationship relation = Relationship.fromString(raw);
+            if (relation == null) {
+                Origins.LOGGER.warn("Unknown relationship '{}' for bi-entity action '{}'", raw, id);
+                return null;
+            }
+            parsed = Optional.of(relation);
+        }
+        return new BiEntityAction(parsed);
+    }
+
+    public static Codec<BiEntityAction> codec() {
+        return CODEC;
+    }
+
+    /**
+     * Bundles the attacker and target entities for bi-entity actions.
+     */
+    public record BiEntityContext(Entity actor, Entity target) {
+    }
+
+    /**
+     * Enumerates the common relationships found in Fabric datapacks.
+     */
+    public enum Relationship {
+        ATTACKER,
+        TARGET,
+        ANY;
+
+        public static Relationship fromString(String value) {
+            try {
+                return Relationship.valueOf(value.toUpperCase());
+            } catch (IllegalArgumentException exception) {
+                return null;
+            }
+        }
+
+        public String serializedName() {
+            return name().toLowerCase();
+        }
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/BlockAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/BlockAction.java
@@ -1,0 +1,62 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.level.Level;
+
+import java.util.Optional;
+
+/**
+ * Scaffold implementation for block based datapack actions.
+ */
+public final class BlockAction implements Action<BlockAction.BlockActionContext> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "block");
+    private static final Codec<BlockAction> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        ResourceLocation.CODEC.optionalFieldOf("block").forGetter(BlockAction::blockId)
+    ).apply(instance, BlockAction::new));
+
+    private final Optional<ResourceLocation> blockId;
+
+    private BlockAction(Optional<ResourceLocation> blockId) {
+        this.blockId = blockId;
+    }
+
+    public Optional<ResourceLocation> blockId() {
+        return blockId;
+    }
+
+    @Override
+    public void execute(BlockActionContext context) {
+        // TODO: Implement Fabric parity behaviour for block actions (set/break/place).
+    }
+
+    public static BlockAction fromJson(ResourceLocation id, JsonObject json) {
+        Optional<ResourceLocation> parsed = Optional.empty();
+        if (json.has("block")) {
+            String raw = GsonHelper.getAsString(json, "block");
+            try {
+                parsed = Optional.of(ResourceLocation.parse(raw));
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Failed to parse block action '{}' block id '{}': {}", id, raw, exception.getMessage());
+                return null;
+            }
+        }
+        return new BlockAction(parsed);
+    }
+
+    public static Codec<BlockAction> codec() {
+        return CODEC;
+    }
+
+    /**
+     * Simple context wrapper bundling the world and target position.
+     */
+    public record BlockActionContext(Level level, BlockPos position) {
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/EntityAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/EntityAction.java
@@ -1,0 +1,55 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.Entity;
+
+import java.util.Optional;
+
+/**
+ * Scaffold implementation for entity based datapack actions.
+ */
+public final class EntityAction implements Action<Entity> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "entity");
+    private static final Codec<EntityAction> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        ResourceLocation.CODEC.optionalFieldOf("entity_type").forGetter(EntityAction::entityType)
+    ).apply(instance, EntityAction::new));
+
+    private final Optional<ResourceLocation> entityType;
+
+    private EntityAction(Optional<ResourceLocation> entityType) {
+        this.entityType = entityType;
+    }
+
+    public Optional<ResourceLocation> entityType() {
+        return entityType;
+    }
+
+    @Override
+    public void execute(Entity entity) {
+        // TODO: Implement Fabric parity behaviour for entity actions (effects/damage/etc.).
+    }
+
+    public static EntityAction fromJson(ResourceLocation id, JsonObject json) {
+        Optional<ResourceLocation> parsed = Optional.empty();
+        if (json.has("entity_type")) {
+            String raw = GsonHelper.getAsString(json, "entity_type");
+            try {
+                parsed = Optional.of(ResourceLocation.parse(raw));
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Failed to parse entity action '{}' entity type '{}': {}", id, raw, exception.getMessage());
+                return null;
+            }
+        }
+        return new EntityAction(parsed);
+    }
+
+    public static Codec<EntityAction> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/ItemAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/ItemAction.java
@@ -1,0 +1,55 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Optional;
+
+/**
+ * Scaffold implementation for item based datapack actions.
+ */
+public final class ItemAction implements Action<ItemStack> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "item");
+    private static final Codec<ItemAction> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        ResourceLocation.CODEC.optionalFieldOf("item").forGetter(ItemAction::itemId)
+    ).apply(instance, ItemAction::new));
+
+    private final Optional<ResourceLocation> itemId;
+
+    private ItemAction(Optional<ResourceLocation> itemId) {
+        this.itemId = itemId;
+    }
+
+    public Optional<ResourceLocation> itemId() {
+        return itemId;
+    }
+
+    @Override
+    public void execute(ItemStack stack) {
+        // TODO: Implement Fabric parity behaviour for item actions (give/modify).
+    }
+
+    public static ItemAction fromJson(ResourceLocation id, JsonObject json) {
+        Optional<ResourceLocation> parsed = Optional.empty();
+        if (json.has("item")) {
+            String raw = GsonHelper.getAsString(json, "item");
+            try {
+                parsed = Optional.of(ResourceLocation.parse(raw));
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Failed to parse item action '{}' item id '{}': {}", id, raw, exception.getMessage());
+                return null;
+            }
+        }
+        return new ItemAction(parsed);
+    }
+
+    public static Codec<ItemAction> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/WorldAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/WorldAction.java
@@ -1,0 +1,54 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.level.Level;
+
+import java.util.Optional;
+
+/**
+ * Scaffold implementation for world level datapack actions.
+ */
+public final class WorldAction implements Action<Level> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "world");
+    private static final Codec<WorldAction> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.STRING.optionalFieldOf("event").forGetter(WorldAction::event)
+    ).apply(instance, WorldAction::new));
+
+    private final Optional<String> event;
+
+    private WorldAction(Optional<String> event) {
+        this.event = event;
+    }
+
+    public Optional<String> event() {
+        return event;
+    }
+
+    @Override
+    public void execute(Level level) {
+        // TODO: Implement Fabric parity behaviour for world actions (explosions/weather/etc.).
+    }
+
+    public static WorldAction fromJson(ResourceLocation id, JsonObject json) {
+        Optional<String> parsed = Optional.empty();
+        if (json.has("event")) {
+            String raw = GsonHelper.getAsString(json, "event");
+            if (raw.isBlank()) {
+                Origins.LOGGER.warn("World action '{}' provided a blank event identifier", id);
+                return null;
+            }
+            parsed = Optional.of(raw);
+        }
+        return new WorldAction(parsed);
+    }
+
+    public static Codec<WorldAction> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/registry/ActionRegistry.java
+++ b/src/main/java/io/github/apace100/origins/power/action/registry/ActionRegistry.java
@@ -1,0 +1,85 @@
+package io.github.apace100.origins.power.action.registry;
+
+import com.google.gson.JsonObject;
+import io.github.apace100.origins.power.action.Action;
+import io.github.apace100.origins.power.action.impl.BiEntityAction;
+import io.github.apace100.origins.power.action.impl.BlockAction;
+import io.github.apace100.origins.power.action.impl.EntityAction;
+import io.github.apace100.origins.power.action.impl.ItemAction;
+import io.github.apace100.origins.power.action.impl.WorldAction;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+/**
+ * Registry that bridges datapack action type identifiers to their scaffold implementations.
+ */
+public final class ActionRegistry {
+    private static final Map<ResourceLocation, BiFunction<ResourceLocation, JsonObject, ? extends Action<?>>> FACTORIES = new HashMap<>();
+    private static final Map<ResourceLocation, Action<?>> ACTIONS = new HashMap<>();
+    private static boolean BOOTSTRAPPED;
+
+    private ActionRegistry() {
+    }
+
+    /**
+     * Ensures the default Fabric parity action stubs are registered.
+     */
+    public static void bootstrap() {
+        if (BOOTSTRAPPED) {
+            return;
+        }
+        BOOTSTRAPPED = true;
+        register(ItemAction.TYPE, ItemAction::fromJson);
+        register(BlockAction.TYPE, BlockAction::fromJson);
+        register(EntityAction.TYPE, EntityAction::fromJson);
+        register(BiEntityAction.TYPE, BiEntityAction::fromJson);
+        register(WorldAction.TYPE, WorldAction::fromJson);
+    }
+
+    /**
+     * Registers a new datapack action factory under the supplied identifier.
+     */
+    public static void register(ResourceLocation id, BiFunction<ResourceLocation, JsonObject, ? extends Action<?>> factory) {
+        FACTORIES.put(id, factory);
+    }
+
+    /**
+     * Resolves a datapack action instance for the provided identifier and JSON payload.
+     */
+    public static Optional<Action<?>> create(ResourceLocation typeId, ResourceLocation id, JsonObject json) {
+        bootstrap();
+        BiFunction<ResourceLocation, JsonObject, ? extends Action<?>> factory = FACTORIES.get(typeId);
+        if (factory == null) {
+            return Optional.empty();
+        }
+        Action<?> action = factory.apply(id, json);
+        return Optional.ofNullable(action);
+    }
+
+    /**
+     * Replaces the loaded datapack actions with the supplied map.
+     */
+    public static void setAll(Map<ResourceLocation, Action<?>> values) {
+        ACTIONS.clear();
+        ACTIONS.putAll(values);
+    }
+
+    /**
+     * Looks up a hydrated datapack action by identifier.
+     */
+    public static Optional<Action<?>> lookup(ResourceLocation id) {
+        return Optional.ofNullable(ACTIONS.get(id));
+    }
+
+    /**
+     * Exposes the currently loaded datapack actions.
+     */
+    public static Map<ResourceLocation, Action<?>> entries() {
+        return Collections.unmodifiableMap(ACTIONS);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/Condition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/Condition.java
@@ -1,0 +1,17 @@
+package io.github.apace100.origins.power.condition;
+
+/**
+ * Placeholder contract for Origins datapack conditions.
+ *
+ * @param <T> the context type that will be evaluated against the condition.
+ */
+@FunctionalInterface
+public interface Condition<T> {
+    /**
+     * Evaluates the condition for the supplied context.
+     *
+     * @param context the invocation context defined by the condition type
+     * @return {@code true} if the condition matches, {@code false} otherwise
+     */
+    boolean test(T context);
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/BiomeCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/BiomeCondition.java
@@ -1,0 +1,56 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.core.Holder;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.level.biome.Biome;
+
+/**
+ * Scaffold implementation for biome datapack conditions.
+ */
+public final class BiomeCondition implements Condition<Holder<Biome>> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "biome");
+    private static final Codec<BiomeCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        ResourceLocation.CODEC.fieldOf("biome").forGetter(BiomeCondition::biomeId)
+    ).apply(instance, BiomeCondition::new));
+
+    private final ResourceLocation biomeId;
+
+    private BiomeCondition(ResourceLocation biomeId) {
+        this.biomeId = biomeId;
+    }
+
+    public ResourceLocation biomeId() {
+        return biomeId;
+    }
+
+    @Override
+    public boolean test(Holder<Biome> biome) {
+        // TODO: Match against configured biome ID once registry access is available.
+        return false;
+    }
+
+    public static BiomeCondition fromJson(ResourceLocation id, JsonObject json) {
+        String raw = GsonHelper.getAsString(json, "biome", "");
+        if (raw.isEmpty()) {
+            Origins.LOGGER.warn("Biome condition '{}' is missing required 'biome' field", id);
+            return null;
+        }
+        try {
+            ResourceLocation biomeId = ResourceLocation.parse(raw);
+            return new BiomeCondition(biomeId);
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Biome condition '{}' has invalid biome id '{}': {}", id, raw, exception.getMessage());
+            return null;
+        }
+    }
+
+    public static Codec<BiomeCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/BlockStateCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/BlockStateCondition.java
@@ -1,0 +1,56 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.Optional;
+
+/**
+ * Scaffold implementation for block state datapack conditions.
+ */
+public final class BlockStateCondition implements Condition<BlockState> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "block_state");
+    private static final Codec<BlockStateCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        ResourceLocation.CODEC.optionalFieldOf("block").forGetter(BlockStateCondition::blockId)
+    ).apply(instance, BlockStateCondition::new));
+
+    private final Optional<ResourceLocation> blockId;
+
+    private BlockStateCondition(Optional<ResourceLocation> blockId) {
+        this.blockId = blockId;
+    }
+
+    public Optional<ResourceLocation> blockId() {
+        return blockId;
+    }
+
+    @Override
+    public boolean test(BlockState state) {
+        // TODO: Inspect the supplied block state for registry and property matches.
+        return false;
+    }
+
+    public static BlockStateCondition fromJson(ResourceLocation id, JsonObject json) {
+        Optional<ResourceLocation> parsed = Optional.empty();
+        if (json.has("block")) {
+            String raw = GsonHelper.getAsString(json, "block");
+            try {
+                parsed = Optional.of(ResourceLocation.parse(raw));
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Block state condition '{}' has invalid block id '{}': {}", id, raw, exception.getMessage());
+                return null;
+            }
+        }
+        return new BlockStateCondition(parsed);
+    }
+
+    public static Codec<BlockStateCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/DamageSourceCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/DamageSourceCondition.java
@@ -1,0 +1,55 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.damagesource.DamageSource;
+
+import java.util.Optional;
+
+/**
+ * Scaffold implementation for damage source datapack conditions.
+ */
+public final class DamageSourceCondition implements Condition<DamageSource> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "damage_source");
+    private static final Codec<DamageSourceCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.STRING.optionalFieldOf("tag").forGetter(DamageSourceCondition::tag)
+    ).apply(instance, DamageSourceCondition::new));
+
+    private final Optional<String> tag;
+
+    private DamageSourceCondition(Optional<String> tag) {
+        this.tag = tag;
+    }
+
+    public Optional<String> tag() {
+        return tag;
+    }
+
+    @Override
+    public boolean test(DamageSource source) {
+        // TODO: Inspect the damage source against the configured tag or identifier.
+        return false;
+    }
+
+    public static DamageSourceCondition fromJson(ResourceLocation id, JsonObject json) {
+        Optional<String> parsed = Optional.empty();
+        if (json.has("tag")) {
+            String raw = GsonHelper.getAsString(json, "tag");
+            if (raw.isBlank()) {
+                Origins.LOGGER.warn("Damage source condition '{}' specified an empty tag", id);
+                return null;
+            }
+            parsed = Optional.of(raw);
+        }
+        return new DamageSourceCondition(parsed);
+    }
+
+    public static Codec<DamageSourceCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/DimensionCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/DimensionCondition.java
@@ -1,0 +1,57 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.level.Level;
+
+import java.util.Optional;
+
+/**
+ * Scaffold implementation for dimension datapack conditions.
+ */
+public final class DimensionCondition implements Condition<ResourceKey<Level>> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "dimension");
+    private static final Codec<DimensionCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        ResourceLocation.CODEC.optionalFieldOf("dimension").forGetter(DimensionCondition::dimensionId)
+    ).apply(instance, DimensionCondition::new));
+
+    private final Optional<ResourceLocation> dimensionId;
+
+    private DimensionCondition(Optional<ResourceLocation> dimensionId) {
+        this.dimensionId = dimensionId;
+    }
+
+    public Optional<ResourceLocation> dimensionId() {
+        return dimensionId;
+    }
+
+    @Override
+    public boolean test(ResourceKey<Level> levelKey) {
+        // TODO: Validate the dimension key against the configured id once registries are wired.
+        return dimensionId.isEmpty();
+    }
+
+    public static DimensionCondition fromJson(ResourceLocation id, JsonObject json) {
+        Optional<ResourceLocation> parsed = Optional.empty();
+        if (json.has("dimension")) {
+            String raw = GsonHelper.getAsString(json, "dimension");
+            try {
+                parsed = Optional.of(ResourceLocation.parse(raw));
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Dimension condition '{}' has invalid dimension id '{}': {}", id, raw, exception.getMessage());
+                return null;
+            }
+        }
+        return new DimensionCondition(parsed);
+    }
+
+    public static Codec<DimensionCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/EntityCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/EntityCondition.java
@@ -1,0 +1,56 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.Entity;
+
+import java.util.Optional;
+
+/**
+ * Scaffold implementation for general entity datapack conditions.
+ */
+public final class EntityCondition implements Condition<Entity> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "entity");
+    private static final Codec<EntityCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        ResourceLocation.CODEC.optionalFieldOf("entity_type").forGetter(EntityCondition::entityType)
+    ).apply(instance, EntityCondition::new));
+
+    private final Optional<ResourceLocation> entityType;
+
+    private EntityCondition(Optional<ResourceLocation> entityType) {
+        this.entityType = entityType;
+    }
+
+    public Optional<ResourceLocation> entityType() {
+        return entityType;
+    }
+
+    @Override
+    public boolean test(Entity entity) {
+        // TODO: Validate the entity instance against the configured filters.
+        return false;
+    }
+
+    public static EntityCondition fromJson(ResourceLocation id, JsonObject json) {
+        Optional<ResourceLocation> parsed = Optional.empty();
+        if (json.has("entity_type")) {
+            String raw = GsonHelper.getAsString(json, "entity_type");
+            try {
+                parsed = Optional.of(ResourceLocation.parse(raw));
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Entity condition '{}' has invalid entity type id '{}': {}", id, raw, exception.getMessage());
+                return null;
+            }
+        }
+        return new EntityCondition(parsed);
+    }
+
+    public static Codec<EntityCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/EquippedItemCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/EquippedItemCondition.java
@@ -1,0 +1,56 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Optional;
+
+/**
+ * Scaffold implementation for equipped item datapack conditions.
+ */
+public final class EquippedItemCondition implements Condition<ItemStack> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "equipped_item");
+    private static final Codec<EquippedItemCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        ResourceLocation.CODEC.optionalFieldOf("item").forGetter(EquippedItemCondition::itemId)
+    ).apply(instance, EquippedItemCondition::new));
+
+    private final Optional<ResourceLocation> itemId;
+
+    private EquippedItemCondition(Optional<ResourceLocation> itemId) {
+        this.itemId = itemId;
+    }
+
+    public Optional<ResourceLocation> itemId() {
+        return itemId;
+    }
+
+    @Override
+    public boolean test(ItemStack stack) {
+        // TODO: Inspect the equipped stack against the configured identifier and predicates.
+        return false;
+    }
+
+    public static EquippedItemCondition fromJson(ResourceLocation id, JsonObject json) {
+        Optional<ResourceLocation> parsed = Optional.empty();
+        if (json.has("item")) {
+            String raw = GsonHelper.getAsString(json, "item");
+            try {
+                parsed = Optional.of(ResourceLocation.parse(raw));
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Equipped item condition '{}' has invalid item id '{}': {}", id, raw, exception.getMessage());
+                return null;
+            }
+        }
+        return new EquippedItemCondition(parsed);
+    }
+
+    public static Codec<EquippedItemCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/FluidCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/FluidCondition.java
@@ -1,0 +1,56 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.level.material.FluidState;
+
+import java.util.Optional;
+
+/**
+ * Scaffold implementation for fluid datapack conditions.
+ */
+public final class FluidCondition implements Condition<FluidState> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "fluid");
+    private static final Codec<FluidCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        ResourceLocation.CODEC.optionalFieldOf("fluid").forGetter(FluidCondition::fluidId)
+    ).apply(instance, FluidCondition::new));
+
+    private final Optional<ResourceLocation> fluidId;
+
+    private FluidCondition(Optional<ResourceLocation> fluidId) {
+        this.fluidId = fluidId;
+    }
+
+    public Optional<ResourceLocation> fluidId() {
+        return fluidId;
+    }
+
+    @Override
+    public boolean test(FluidState state) {
+        // TODO: Inspect the supplied fluid state against the configured identifier or tag.
+        return false;
+    }
+
+    public static FluidCondition fromJson(ResourceLocation id, JsonObject json) {
+        Optional<ResourceLocation> parsed = Optional.empty();
+        if (json.has("fluid")) {
+            String raw = GsonHelper.getAsString(json, "fluid");
+            try {
+                parsed = Optional.of(ResourceLocation.parse(raw));
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Fluid condition '{}' has invalid fluid id '{}': {}", id, raw, exception.getMessage());
+                return null;
+            }
+        }
+        return new FluidCondition(parsed);
+    }
+
+    public static Codec<FluidCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/FoodCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/FoodCondition.java
@@ -1,0 +1,61 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * Scaffold implementation for food datapack conditions.
+ */
+public final class FoodCondition implements Condition<Player> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "food");
+    private static final Codec<FoodCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.INT.optionalFieldOf("min", 0).forGetter(FoodCondition::min),
+        Codec.INT.optionalFieldOf("max", 20).forGetter(FoodCondition::max)
+    ).apply(instance, FoodCondition::new));
+
+    private final int min;
+    private final int max;
+
+    private FoodCondition(int min, int max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    public int min() {
+        return min;
+    }
+
+    public int max() {
+        return max;
+    }
+
+    @Override
+    public boolean test(Player player) {
+        // TODO: Compare the player's hunger level against the configured bounds.
+        return false;
+    }
+
+    public static FoodCondition fromJson(ResourceLocation id, JsonObject json) {
+        int min = GsonHelper.getAsInt(json, "min", 0);
+        int max = GsonHelper.getAsInt(json, "max", 20);
+        if (min < 0 || max < 0) {
+            Origins.LOGGER.warn("Food condition '{}' has negative hunger bounds ({}, {})", id, min, max);
+            return null;
+        }
+        if (min > max) {
+            Origins.LOGGER.warn("Food condition '{}' has inverted hunger bounds ({}, {})", id, min, max);
+            return null;
+        }
+        return new FoodCondition(min, max);
+    }
+
+    public static Codec<FoodCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/TimeOfDayCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/TimeOfDayCondition.java
@@ -1,0 +1,57 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.level.Level;
+
+/**
+ * Scaffold implementation for time of day datapack conditions.
+ */
+public final class TimeOfDayCondition implements Condition<Level> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "time_of_day");
+    private static final Codec<TimeOfDayCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.INT.optionalFieldOf("start", 0).forGetter(TimeOfDayCondition::startTime),
+        Codec.INT.optionalFieldOf("end", 24000).forGetter(TimeOfDayCondition::endTime)
+    ).apply(instance, TimeOfDayCondition::new));
+
+    private final int startTime;
+    private final int endTime;
+
+    private TimeOfDayCondition(int startTime, int endTime) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public int startTime() {
+        return startTime;
+    }
+
+    public int endTime() {
+        return endTime;
+    }
+
+    @Override
+    public boolean test(Level level) {
+        // TODO: Compare against world time respecting wrap-around semantics.
+        return false;
+    }
+
+    public static TimeOfDayCondition fromJson(ResourceLocation id, JsonObject json) {
+        int start = GsonHelper.getAsInt(json, "start", 0);
+        int end = GsonHelper.getAsInt(json, "end", 24000);
+        if (start < 0 || end < 0) {
+            Origins.LOGGER.warn("Time of day condition '{}' has negative range ({}, {})", id, start, end);
+            return null;
+        }
+        return new TimeOfDayCondition(start, end);
+    }
+
+    public static Codec<TimeOfDayCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/registry/ConditionRegistry.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/registry/ConditionRegistry.java
@@ -1,0 +1,93 @@
+package io.github.apace100.origins.power.condition.registry;
+
+import com.google.gson.JsonObject;
+import io.github.apace100.origins.power.condition.Condition;
+import io.github.apace100.origins.power.condition.impl.BiomeCondition;
+import io.github.apace100.origins.power.condition.impl.BlockStateCondition;
+import io.github.apace100.origins.power.condition.impl.DamageSourceCondition;
+import io.github.apace100.origins.power.condition.impl.DimensionCondition;
+import io.github.apace100.origins.power.condition.impl.EquippedItemCondition;
+import io.github.apace100.origins.power.condition.impl.FluidCondition;
+import io.github.apace100.origins.power.condition.impl.FoodCondition;
+import io.github.apace100.origins.power.condition.impl.TimeOfDayCondition;
+import io.github.apace100.origins.power.condition.impl.EntityCondition;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+/**
+ * Registry that bridges datapack condition identifiers to their scaffold implementations.
+ */
+public final class ConditionRegistry {
+    private static final Map<ResourceLocation, BiFunction<ResourceLocation, JsonObject, ? extends Condition<?>>> FACTORIES = new HashMap<>();
+    private static final Map<ResourceLocation, Condition<?>> CONDITIONS = new HashMap<>();
+    private static boolean BOOTSTRAPPED;
+
+    private ConditionRegistry() {
+    }
+
+    /**
+     * Ensures the default Fabric parity condition stubs are registered.
+     */
+    public static void bootstrap() {
+        if (BOOTSTRAPPED) {
+            return;
+        }
+        BOOTSTRAPPED = true;
+        register(BiomeCondition.TYPE, BiomeCondition::fromJson);
+        register(DimensionCondition.TYPE, DimensionCondition::fromJson);
+        register(TimeOfDayCondition.TYPE, TimeOfDayCondition::fromJson);
+        register(DamageSourceCondition.TYPE, DamageSourceCondition::fromJson);
+        register(BlockStateCondition.TYPE, BlockStateCondition::fromJson);
+        register(EquippedItemCondition.TYPE, EquippedItemCondition::fromJson);
+        register(FluidCondition.TYPE, FluidCondition::fromJson);
+        register(FoodCondition.TYPE, FoodCondition::fromJson);
+        register(EntityCondition.TYPE, EntityCondition::fromJson);
+    }
+
+    /**
+     * Registers a new datapack condition factory under the supplied identifier.
+     */
+    public static void register(ResourceLocation id, BiFunction<ResourceLocation, JsonObject, ? extends Condition<?>> factory) {
+        FACTORIES.put(id, factory);
+    }
+
+    /**
+     * Resolves a datapack condition instance for the provided identifier and JSON payload.
+     */
+    public static Optional<Condition<?>> create(ResourceLocation typeId, ResourceLocation id, JsonObject json) {
+        bootstrap();
+        BiFunction<ResourceLocation, JsonObject, ? extends Condition<?>> factory = FACTORIES.get(typeId);
+        if (factory == null) {
+            return Optional.empty();
+        }
+        Condition<?> condition = factory.apply(id, json);
+        return Optional.ofNullable(condition);
+    }
+
+    /**
+     * Replaces the loaded datapack conditions with the supplied map.
+     */
+    public static void setAll(Map<ResourceLocation, Condition<?>> values) {
+        CONDITIONS.clear();
+        CONDITIONS.putAll(values);
+    }
+
+    /**
+     * Looks up a hydrated datapack condition by identifier.
+     */
+    public static Optional<Condition<?>> lookup(ResourceLocation id) {
+        return Optional.ofNullable(CONDITIONS.get(id));
+    }
+
+    /**
+     * Exposes the currently loaded datapack conditions.
+     */
+    public static Map<ResourceLocation, Condition<?>> entries() {
+        return Collections.unmodifiableMap(CONDITIONS);
+    }
+}


### PR DESCRIPTION
## Summary
- add power action/condition interfaces, stub implementations, and registries with JSON factories for Fabric parity work
- integrate OriginsDataLoader with the new registries and expand reload statistics/logging to cover actions and conditions

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68dd81d5979883279ba14a13a2d2bc4b