### PR TITLE
Implement core datapack actions and conditions

### DIFF
--- a/src/main/java/io/github/apace100/origins/power/action/impl/DamageEntityAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/DamageEntityAction.java
@@ -1,0 +1,100 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageType;
+import net.minecraft.world.entity.Entity;
+
+/**
+ * Datapack action that applies damage to the context entity.
+ */
+public final class DamageEntityAction implements Action<Entity> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "damage_entity");
+    private static final Codec<DamageEntityAction> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.FLOAT.fieldOf("amount").forGetter(DamageEntityAction::amount),
+        ResourceLocation.CODEC.fieldOf("source").forGetter(DamageEntityAction::sourceId)
+    ).apply(instance, DamageEntityAction::new));
+
+    private final float amount;
+    private final ResourceLocation sourceId;
+    private boolean missingDamageTypeLogged;
+
+    private DamageEntityAction(float amount, ResourceLocation sourceId) {
+        this.amount = amount;
+        this.sourceId = sourceId;
+    }
+
+    private float amount() {
+        return amount;
+    }
+
+    private ResourceLocation sourceId() {
+        return sourceId;
+    }
+
+    @Override
+    public void execute(Entity entity) {
+        if (entity == null || amount <= 0) {
+            return;
+        }
+        if (!(entity.level() instanceof ServerLevel level)) {
+            return;
+        }
+
+        Registry<DamageType> registry = level.registryAccess().registryOrThrow(Registries.DAMAGE_TYPE);
+        ResourceKey<DamageType> key = ResourceKey.create(Registries.DAMAGE_TYPE, sourceId);
+        Holder<DamageType> holder = registry.getHolder(key).orElse(null);
+        if (holder == null) {
+            if (!missingDamageTypeLogged) {
+                Origins.LOGGER.warn("Damage entity action could not resolve damage type '{}'", sourceId);
+                missingDamageTypeLogged = true;
+            }
+            return;
+        }
+
+        entity.hurt(new DamageSource(holder), amount);
+    }
+
+    public static DamageEntityAction fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("amount")) {
+            Origins.LOGGER.warn("Damage entity action '{}' is missing required 'amount' field", id);
+            return null;
+        }
+        if (!json.has("source")) {
+            Origins.LOGGER.warn("Damage entity action '{}' is missing required 'source' field", id);
+            return null;
+        }
+
+        float amount = (float) GsonHelper.getAsDouble(json, "amount");
+        if (amount <= 0) {
+            Origins.LOGGER.warn("Damage entity action '{}' has non-positive amount {}", id, amount);
+            return null;
+        }
+
+        String rawSource = GsonHelper.getAsString(json, "source");
+        ResourceLocation sourceId;
+        try {
+            sourceId = ResourceLocation.parse(rawSource);
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Damage entity action '{}' has invalid damage source id '{}': {}", id, rawSource, exception.getMessage());
+            return null;
+        }
+
+        return new DamageEntityAction(amount, sourceId);
+    }
+
+    public static Codec<DamageEntityAction> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/GiveItemAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/GiveItemAction.java
@@ -1,0 +1,88 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Optional;
+
+/**
+ * Datapack action that gives a configured item stack to the invoking player.
+ */
+public final class GiveItemAction implements Action<Player> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "give_item");
+    private static final Codec<GiveItemAction> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        BuiltInRegistries.ITEM.byNameCodec().fieldOf("item").forGetter(GiveItemAction::item),
+        Codec.INT.optionalFieldOf("count", 1).forGetter(GiveItemAction::count)
+    ).apply(instance, GiveItemAction::new));
+
+    private final Item item;
+    private final int count;
+
+    private GiveItemAction(Item item, int count) {
+        this.item = item;
+        this.count = count;
+    }
+
+    private Item item() {
+        return item;
+    }
+
+    private int count() {
+        return count;
+    }
+
+    @Override
+    public void execute(Player player) {
+        if (player == null || count <= 0) {
+            return;
+        }
+
+        ItemStack stack = new ItemStack(item, count);
+        if (!player.addItem(stack)) {
+            player.drop(stack, false);
+        }
+    }
+
+    public static GiveItemAction fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("item")) {
+            Origins.LOGGER.warn("Give item action '{}' is missing required 'item' field", id);
+            return null;
+        }
+
+        String rawItem = GsonHelper.getAsString(json, "item");
+        ResourceLocation itemId;
+        try {
+            itemId = ResourceLocation.parse(rawItem);
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Give item action '{}' has invalid item id '{}': {}", id, rawItem, exception.getMessage());
+            return null;
+        }
+
+        Optional<Item> item = BuiltInRegistries.ITEM.getOptional(itemId);
+        if (item.isEmpty()) {
+            Origins.LOGGER.warn("Give item action '{}' references unknown item '{}'", id, itemId);
+            return null;
+        }
+
+        int count = GsonHelper.getAsInt(json, "count", 1);
+        if (count <= 0) {
+            Origins.LOGGER.warn("Give item action '{}' has non-positive count {}", id, count);
+            return null;
+        }
+
+        return new GiveItemAction(item.get(), count);
+    }
+
+    public static Codec<GiveItemAction> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/SetBlockAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/SetBlockAction.java
@@ -1,0 +1,103 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.Optional;
+
+/**
+ * Datapack action that replaces a block at the configured position.
+ */
+public final class SetBlockAction implements Action<ServerLevel> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "set_block");
+    private static final Codec<SetBlockAction> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        BuiltInRegistries.BLOCK.byNameCodec().xmap(Block::defaultBlockState, BlockState::getBlock).fieldOf("block").forGetter(SetBlockAction::state),
+        BlockPos.CODEC.fieldOf("pos").forGetter(SetBlockAction::pos)
+    ).apply(instance, SetBlockAction::new));
+
+    private final BlockState state;
+    private final BlockPos pos;
+
+    private SetBlockAction(BlockState state, BlockPos pos) {
+        this.state = state;
+        this.pos = pos;
+    }
+
+    private BlockState state() {
+        return state;
+    }
+
+    private BlockPos pos() {
+        return pos;
+    }
+
+    @Override
+    public void execute(ServerLevel level) {
+        if (level == null) {
+            return;
+        }
+
+        level.setBlockAndUpdate(pos, state);
+    }
+
+    public static SetBlockAction fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("block")) {
+            Origins.LOGGER.warn("Set block action '{}' is missing required 'block' field", id);
+            return null;
+        }
+        if (!json.has("pos")) {
+            Origins.LOGGER.warn("Set block action '{}' is missing required 'pos' field", id);
+            return null;
+        }
+
+        String rawBlock = GsonHelper.getAsString(json, "block");
+        ResourceLocation blockId;
+        try {
+            blockId = ResourceLocation.parse(rawBlock);
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Set block action '{}' has invalid block id '{}': {}", id, rawBlock, exception.getMessage());
+            return null;
+        }
+
+        Optional<Block> block = BuiltInRegistries.BLOCK.getOptional(blockId);
+        if (block.isEmpty()) {
+            Origins.LOGGER.warn("Set block action '{}' references unknown block '{}'", id, blockId);
+            return null;
+        }
+
+        JsonArray array = GsonHelper.getAsJsonArray(json, "pos");
+        if (array.size() != 3) {
+            Origins.LOGGER.warn("Set block action '{}' position must contain exactly 3 elements", id);
+            return null;
+        }
+
+        int x;
+        int y;
+        int z;
+        try {
+            x = GsonHelper.convertToInt(array.get(0), "pos[0]");
+            y = GsonHelper.convertToInt(array.get(1), "pos[1]");
+            z = GsonHelper.convertToInt(array.get(2), "pos[2]");
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Set block action '{}' has invalid position values: {}", id, exception.getMessage());
+            return null;
+        }
+
+        return new SetBlockAction(block.get().defaultBlockState(), new BlockPos(x, y, z));
+    }
+
+    public static Codec<SetBlockAction> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/SpawnEntityAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/SpawnEntityAction.java
@@ -1,0 +1,109 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.Optional;
+
+/**
+ * Datapack action that spawns an entity at the configured position.
+ */
+public final class SpawnEntityAction implements Action<ServerLevel> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "spawn_entity");
+    private static final Codec<SpawnEntityAction> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        BuiltInRegistries.ENTITY_TYPE.byNameCodec().fieldOf("entity").forGetter(SpawnEntityAction::type),
+        Vec3.CODEC.fieldOf("pos").forGetter(SpawnEntityAction::position)
+    ).apply(instance, SpawnEntityAction::new));
+
+    private final EntityType<?> type;
+    private final Vec3 position;
+
+    private SpawnEntityAction(EntityType<?> type, Vec3 position) {
+        this.type = type;
+        this.position = position;
+    }
+
+    private EntityType<?> type() {
+        return type;
+    }
+
+    private Vec3 position() {
+        return position;
+    }
+
+    @Override
+    public void execute(ServerLevel level) {
+        if (level == null) {
+            return;
+        }
+
+        Entity entity = type.create(level);
+        if (entity == null) {
+            return;
+        }
+
+        entity.moveTo(position.x, position.y, position.z, entity.getYRot(), entity.getXRot());
+        level.addFreshEntity(entity);
+    }
+
+    public static SpawnEntityAction fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("entity")) {
+            Origins.LOGGER.warn("Spawn entity action '{}' is missing required 'entity' field", id);
+            return null;
+        }
+        if (!json.has("pos")) {
+            Origins.LOGGER.warn("Spawn entity action '{}' is missing required 'pos' field", id);
+            return null;
+        }
+
+        String rawEntity = GsonHelper.getAsString(json, "entity");
+        ResourceLocation entityId;
+        try {
+            entityId = ResourceLocation.parse(rawEntity);
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Spawn entity action '{}' has invalid entity id '{}': {}", id, rawEntity, exception.getMessage());
+            return null;
+        }
+
+        Optional<EntityType<?>> entityType = BuiltInRegistries.ENTITY_TYPE.getOptional(entityId);
+        if (entityType.isEmpty()) {
+            Origins.LOGGER.warn("Spawn entity action '{}' references unknown entity '{}'", id, entityId);
+            return null;
+        }
+
+        JsonArray array = GsonHelper.getAsJsonArray(json, "pos");
+        if (array.size() != 3) {
+            Origins.LOGGER.warn("Spawn entity action '{}' position must contain exactly 3 elements", id);
+            return null;
+        }
+
+        double x;
+        double y;
+        double z;
+        try {
+            x = GsonHelper.convertToDouble(array.get(0), "pos[0]");
+            y = GsonHelper.convertToDouble(array.get(1), "pos[1]");
+            z = GsonHelper.convertToDouble(array.get(2), "pos[2]");
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Spawn entity action '{}' has invalid position values: {}", id, exception.getMessage());
+            return null;
+        }
+
+        return new SpawnEntityAction(entityType.get(), new Vec3(x, y, z));
+    }
+
+    public static Codec<SpawnEntityAction> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/registry/ActionRegistry.java
+++ b/src/main/java/io/github/apace100/origins/power/action/registry/ActionRegistry.java
@@ -4,8 +4,12 @@ import com.google.gson.JsonObject;
 import io.github.apace100.origins.power.action.Action;
 import io.github.apace100.origins.power.action.impl.BiEntityAction;
 import io.github.apace100.origins.power.action.impl.BlockAction;
+import io.github.apace100.origins.power.action.impl.DamageEntityAction;
 import io.github.apace100.origins.power.action.impl.EntityAction;
+import io.github.apace100.origins.power.action.impl.GiveItemAction;
 import io.github.apace100.origins.power.action.impl.ItemAction;
+import io.github.apace100.origins.power.action.impl.SetBlockAction;
+import io.github.apace100.origins.power.action.impl.SpawnEntityAction;
 import io.github.apace100.origins.power.action.impl.WorldAction;
 import net.minecraft.resources.ResourceLocation;
 
@@ -39,6 +43,10 @@ public final class ActionRegistry {
         register(EntityAction.TYPE, EntityAction::fromJson);
         register(BiEntityAction.TYPE, BiEntityAction::fromJson);
         register(WorldAction.TYPE, WorldAction::fromJson);
+        register(GiveItemAction.TYPE, GiveItemAction::fromJson);
+        register(SetBlockAction.TYPE, SetBlockAction::fromJson);
+        register(SpawnEntityAction.TYPE, SpawnEntityAction::fromJson);
+        register(DamageEntityAction.TYPE, DamageEntityAction::fromJson);
     }
 
     /**

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/DimensionCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/DimensionCondition.java
@@ -5,50 +5,53 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.github.apace100.origins.Origins;
 import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.level.Level;
-
-import java.util.Optional;
 
 /**
  * Scaffold implementation for dimension datapack conditions.
  */
-public final class DimensionCondition implements Condition<ResourceKey<Level>> {
+public final class DimensionCondition implements Condition<ServerLevel> {
     public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "dimension");
     private static final Codec<DimensionCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-        ResourceLocation.CODEC.optionalFieldOf("dimension").forGetter(DimensionCondition::dimensionId)
+        ResourceKey.codec(Registries.DIMENSION).fieldOf("dimension").forGetter(DimensionCondition::dimensionKey)
     ).apply(instance, DimensionCondition::new));
 
-    private final Optional<ResourceLocation> dimensionId;
+    private final ResourceKey<Level> dimensionKey;
 
-    private DimensionCondition(Optional<ResourceLocation> dimensionId) {
-        this.dimensionId = dimensionId;
+    private DimensionCondition(ResourceKey<Level> dimensionKey) {
+        this.dimensionKey = dimensionKey;
     }
 
-    public Optional<ResourceLocation> dimensionId() {
-        return dimensionId;
+    public ResourceKey<Level> dimensionKey() {
+        return dimensionKey;
     }
 
     @Override
-    public boolean test(ResourceKey<Level> levelKey) {
-        // TODO: Validate the dimension key against the configured id once registries are wired.
-        return dimensionId.isEmpty();
+    public boolean test(ServerLevel level) {
+        return level != null && level.dimension().equals(dimensionKey);
     }
 
     public static DimensionCondition fromJson(ResourceLocation id, JsonObject json) {
-        Optional<ResourceLocation> parsed = Optional.empty();
-        if (json.has("dimension")) {
-            String raw = GsonHelper.getAsString(json, "dimension");
-            try {
-                parsed = Optional.of(ResourceLocation.parse(raw));
-            } catch (IllegalArgumentException exception) {
-                Origins.LOGGER.warn("Dimension condition '{}' has invalid dimension id '{}': {}", id, raw, exception.getMessage());
-                return null;
-            }
+        if (!json.has("dimension")) {
+            Origins.LOGGER.warn("Dimension condition '{}' is missing required 'dimension' field", id);
+            return null;
         }
-        return new DimensionCondition(parsed);
+
+        String raw = GsonHelper.getAsString(json, "dimension");
+        ResourceLocation dimensionId;
+        try {
+            dimensionId = ResourceLocation.parse(raw);
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Dimension condition '{}' has invalid dimension id '{}': {}", id, raw, exception.getMessage());
+            return null;
+        }
+
+        return new DimensionCondition(ResourceKey.create(Registries.DIMENSION, dimensionId));
     }
 
     public static Codec<DimensionCondition> codec() {

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/TimeOfDayCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/TimeOfDayCondition.java
@@ -1,30 +1,34 @@
 package io.github.apace100.origins.power.condition.impl;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.github.apace100.origins.Origins;
 import io.github.apace100.origins.power.condition.Condition;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.GsonHelper;
-import net.minecraft.world.level.Level;
+
+import java.util.List;
 
 /**
  * Scaffold implementation for time of day datapack conditions.
  */
-public final class TimeOfDayCondition implements Condition<Level> {
+public final class TimeOfDayCondition implements Condition<ServerLevel> {
     public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "time_of_day");
+    private static final Codec<List<Integer>> RANGE_CODEC = Codec.INT.listOf().flatXmap(TimeOfDayCondition::validateRange, TimeOfDayCondition::validateRange);
     private static final Codec<TimeOfDayCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-        Codec.INT.optionalFieldOf("start", 0).forGetter(TimeOfDayCondition::startTime),
-        Codec.INT.optionalFieldOf("end", 24000).forGetter(TimeOfDayCondition::endTime)
-    ).apply(instance, TimeOfDayCondition::new));
+        RANGE_CODEC.fieldOf("range").forGetter(TimeOfDayCondition::range)
+    ).apply(instance, range -> new TimeOfDayCondition(range.get(0), range.get(1))));
 
     private final int startTime;
     private final int endTime;
 
     private TimeOfDayCondition(int startTime, int endTime) {
-        this.startTime = startTime;
-        this.endTime = endTime;
+        this.startTime = normalize(startTime);
+        this.endTime = normalize(endTime);
     }
 
     public int startTime() {
@@ -36,22 +40,75 @@ public final class TimeOfDayCondition implements Condition<Level> {
     }
 
     @Override
-    public boolean test(Level level) {
-        // TODO: Compare against world time respecting wrap-around semantics.
-        return false;
+    public boolean test(ServerLevel level) {
+        if (level == null) {
+            return false;
+        }
+
+        int time = (int) (level.getDayTime() % 24000L);
+        if (time < 0) {
+            time += 24000;
+        }
+
+        if (startTime <= endTime) {
+            return time >= startTime && time <= endTime;
+        }
+        return time >= startTime || time <= endTime;
     }
 
     public static TimeOfDayCondition fromJson(ResourceLocation id, JsonObject json) {
-        int start = GsonHelper.getAsInt(json, "start", 0);
-        int end = GsonHelper.getAsInt(json, "end", 24000);
+        if (!json.has("range")) {
+            Origins.LOGGER.warn("Time of day condition '{}' is missing required 'range' field", id);
+            return null;
+        }
+
+        JsonArray range = GsonHelper.getAsJsonArray(json, "range");
+        if (range.size() != 2) {
+            Origins.LOGGER.warn("Time of day condition '{}' range must contain exactly 2 elements", id);
+            return null;
+        }
+
+        int start;
+        int end;
+        try {
+            start = GsonHelper.convertToInt(range.get(0), "range[0]");
+            end = GsonHelper.convertToInt(range.get(1), "range[1]");
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Time of day condition '{}' has invalid range values: {}", id, exception.getMessage());
+            return null;
+        }
+
         if (start < 0 || end < 0) {
             Origins.LOGGER.warn("Time of day condition '{}' has negative range ({}, {})", id, start, end);
             return null;
         }
+
         return new TimeOfDayCondition(start, end);
     }
 
     public static Codec<TimeOfDayCondition> codec() {
         return CODEC;
+    }
+
+    private List<Integer> range() {
+        return List.of(startTime, endTime);
+    }
+
+    private static DataResult<List<Integer>> validateRange(List<Integer> values) {
+        if (values.size() != 2) {
+            return DataResult.error(() -> "Time of day range must have exactly 2 values");
+        }
+        if (values.get(0) < 0 || values.get(1) < 0) {
+            return DataResult.error(() -> "Time of day range values must be non-negative");
+        }
+        return DataResult.success(values);
+    }
+
+    private static int normalize(int value) {
+        int wrapped = value % 24000;
+        if (wrapped < 0) {
+            wrapped += 24000;
+        }
+        return wrapped;
     }
 }


### PR DESCRIPTION
## Summary
- implement give item, set block, spawn entity, and damage entity datapack actions with JSON validation and runtime behaviour
- flesh out biome, dimension, time of day, and block state conditions to evaluate against live game state
- register the new action factories in the action registry for datapack loading

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68dd85ab4bdc8327be4705859b83147d