### PR TITLE
Add entity/composite condition implementations and tracking

### DIFF
--- a/src/main/java/io/github/apace100/origins/datapack/DataValidationLogger.java
+++ b/src/main/java/io/github/apace100/origins/datapack/DataValidationLogger.java
@@ -18,8 +18,9 @@ public final class DataValidationLogger extends SimplePreparableReloadListener<V
     @Override
     protected void apply(Void value, ResourceManager resourceManager, ProfilerFiller profiler) {
         ReloadStats stats = OriginsDataLoader.getLastReloadStats();
-        Origins.LOGGER.info("[Origins] Datapack reload summary: {} origins, {} powers, {} actions, {} conditions",
-            stats.originsLoaded(), stats.powersLoaded(), stats.actionsLoaded(), stats.conditionsLoaded());
+        Origins.LOGGER.info("[Origins] Datapack reload summary: {} origins, {} powers, {} actions, {} conditions ({} entity / {} composite)",
+            stats.originsLoaded(), stats.powersLoaded(), stats.actionsLoaded(), stats.conditionsLoaded(),
+            stats.entityConditionsLoaded(), stats.compositeConditionsLoaded());
         if (stats.skippedEntries() > 0) {
             Origins.LOGGER.info("[Origins] Datapack skipped {} entries during reload", stats.skippedEntries());
         }

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/AllOfCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/AllOfCondition.java
@@ -1,0 +1,82 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Datapack condition that succeeds when all nested conditions pass.
+ */
+public final class AllOfCondition implements Condition<Object> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "all_of");
+
+    private final List<Condition<Object>> conditions;
+
+    private AllOfCondition(List<Condition<Object>> conditions) {
+        this.conditions = List.copyOf(conditions);
+    }
+
+    @Override
+    public boolean test(Object context) {
+        for (Condition<Object> condition : conditions) {
+            if (!condition.test(context)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static AllOfCondition fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("conditions")) {
+            Origins.LOGGER.warn("All of condition '{}' is missing required 'conditions' array", id);
+            return null;
+        }
+
+        JsonElement element = json.get("conditions");
+        if (!element.isJsonArray()) {
+            Origins.LOGGER.warn("All of condition '{}' provided non-array 'conditions' entry", id);
+            return null;
+        }
+
+        JsonArray array = element.getAsJsonArray();
+        if (array.isEmpty()) {
+            Origins.LOGGER.warn("All of condition '{}' provided an empty 'conditions' array", id);
+            return null;
+        }
+
+        List<Condition<Object>> children = new ArrayList<>();
+        boolean failed = false;
+        for (int i = 0; i < array.size(); i++) {
+            JsonElement childElement = array.get(i);
+            if (!childElement.isJsonObject()) {
+                Origins.LOGGER.warn("All of condition '{}' has non-object child at conditions[{}]", id, i);
+                failed = true;
+                continue;
+            }
+
+            JsonObject childJson = childElement.getAsJsonObject();
+            Optional<Condition<?>> nested = ConditionFactoryUtil.resolveNestedCondition(id, childJson, "conditions[" + i + "]", "conditions/" + i);
+            if (nested.isEmpty()) {
+                failed = true;
+                continue;
+            }
+
+            @SuppressWarnings("unchecked")
+            Condition<Object> casted = (Condition<Object>) nested.get();
+            children.add(casted);
+        }
+
+        if (failed || children.isEmpty()) {
+            return null;
+        }
+
+        return new AllOfCondition(children);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/AnyOfCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/AnyOfCondition.java
@@ -1,0 +1,82 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Datapack condition that succeeds when any nested condition passes.
+ */
+public final class AnyOfCondition implements Condition<Object> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "any_of");
+
+    private final List<Condition<Object>> conditions;
+
+    private AnyOfCondition(List<Condition<Object>> conditions) {
+        this.conditions = List.copyOf(conditions);
+    }
+
+    @Override
+    public boolean test(Object context) {
+        for (Condition<Object> condition : conditions) {
+            if (condition.test(context)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static AnyOfCondition fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("conditions")) {
+            Origins.LOGGER.warn("Any of condition '{}' is missing required 'conditions' array", id);
+            return null;
+        }
+
+        JsonElement element = json.get("conditions");
+        if (!element.isJsonArray()) {
+            Origins.LOGGER.warn("Any of condition '{}' provided non-array 'conditions' entry", id);
+            return null;
+        }
+
+        JsonArray array = element.getAsJsonArray();
+        if (array.isEmpty()) {
+            Origins.LOGGER.warn("Any of condition '{}' provided an empty 'conditions' array", id);
+            return null;
+        }
+
+        List<Condition<Object>> children = new ArrayList<>();
+        boolean failed = false;
+        for (int i = 0; i < array.size(); i++) {
+            JsonElement childElement = array.get(i);
+            if (!childElement.isJsonObject()) {
+                Origins.LOGGER.warn("Any of condition '{}' has non-object child at conditions[{}]", id, i);
+                failed = true;
+                continue;
+            }
+
+            JsonObject childJson = childElement.getAsJsonObject();
+            Optional<Condition<?>> nested = ConditionFactoryUtil.resolveNestedCondition(id, childJson, "conditions[" + i + "]", "conditions/" + i);
+            if (nested.isEmpty()) {
+                failed = true;
+                continue;
+            }
+
+            @SuppressWarnings("unchecked")
+            Condition<Object> casted = (Condition<Object>) nested.get();
+            children.add(casted);
+        }
+
+        if (failed || children.isEmpty()) {
+            return null;
+        }
+
+        return new AnyOfCondition(children);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/ConditionFactoryUtil.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/ConditionFactoryUtil.java
@@ -1,0 +1,71 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import io.github.apace100.origins.power.condition.registry.ConditionRegistry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Shared JSON parsing utilities for condition factory implementations.
+ */
+final class ConditionFactoryUtil {
+    private ConditionFactoryUtil() {
+    }
+
+    static Optional<Condition<?>> resolveNestedCondition(ResourceLocation parentId, JsonObject json, String description, String pathSuffix) {
+        Optional<ResourceLocation> typeId = parseType(parentId, json, description);
+        if (typeId.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ResourceLocation nestedId = nestedId(parentId, pathSuffix);
+        Optional<Condition<?>> nested = ConditionRegistry.create(typeId.get(), nestedId, json);
+        if (nested.isEmpty()) {
+            Origins.LOGGER.warn("Condition '{}' {} has unknown type '{}'", parentId, description, typeId.get());
+        }
+        return nested;
+    }
+
+    static Optional<ResourceLocation> parseType(ResourceLocation parentId, JsonObject json, String description) {
+        if (!json.has("type")) {
+            Origins.LOGGER.warn("Condition '{}' {} is missing required 'type' field", parentId, description);
+            return Optional.empty();
+        }
+
+        String rawType = GsonHelper.getAsString(json, "type", "");
+        if (rawType.isEmpty()) {
+            Origins.LOGGER.warn("Condition '{}' {} specified an empty 'type'", parentId, description);
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(ResourceLocation.parse(rawType));
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Condition '{}' {} has invalid type '{}': {}", parentId, description, rawType, exception.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private static ResourceLocation nestedId(ResourceLocation parentId, String suffix) {
+        String normalizedSuffix = normalizeSuffix(suffix);
+        String parentPath = parentId.getPath();
+        if (parentPath.isEmpty()) {
+            return ResourceLocation.fromNamespaceAndPath(parentId.getNamespace(), normalizedSuffix);
+        }
+        String delimiter = parentPath.endsWith("/") ? "" : "/";
+        return ResourceLocation.fromNamespaceAndPath(parentId.getNamespace(), parentPath + delimiter + normalizedSuffix);
+    }
+
+    private static String normalizeSuffix(String suffix) {
+        String normalized = suffix.toLowerCase(Locale.ROOT).replace(' ', '_');
+        if (normalized.startsWith("/")) {
+            return normalized.substring(1);
+        }
+        return normalized;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/HealthCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/HealthCondition.java
@@ -1,0 +1,62 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.LivingEntity;
+
+/**
+ * Datapack condition that validates a living entity's health against a configured range.
+ */
+public final class HealthCondition implements Condition<LivingEntity> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "health");
+
+    private final float minHealth;
+    private final float maxHealth;
+
+    private HealthCondition(float minHealth, float maxHealth) {
+        this.minHealth = minHealth;
+        this.maxHealth = maxHealth;
+    }
+
+    @Override
+    public boolean test(LivingEntity entity) {
+        if (entity == null) {
+            return false;
+        }
+        float health = entity.getHealth();
+        return health >= minHealth && health <= maxHealth;
+    }
+
+    public static HealthCondition fromJson(ResourceLocation id, JsonObject json) {
+        float min = 0.0F;
+        float max = Float.MAX_VALUE;
+
+        if (json.has("min")) {
+            try {
+                min = GsonHelper.getAsFloat(json, "min");
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Health condition '{}' has invalid 'min' value: {}", id, exception.getMessage());
+                return null;
+            }
+        }
+
+        if (json.has("max")) {
+            try {
+                max = GsonHelper.getAsFloat(json, "max");
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Health condition '{}' has invalid 'max' value: {}", id, exception.getMessage());
+                return null;
+            }
+        }
+
+        if (max < min) {
+            Origins.LOGGER.warn("Health condition '{}' has max ({}) smaller than min ({})", id, max, min);
+            return null;
+        }
+
+        return new HealthCondition(min, max);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/InvertedCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/InvertedCondition.java
@@ -1,0 +1,51 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+
+import java.util.Optional;
+
+/**
+ * Datapack condition that inverts the result of another condition.
+ */
+public final class InvertedCondition implements Condition<Object> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "inverted");
+
+    private final Condition<Object> condition;
+
+    private InvertedCondition(Condition<Object> condition) {
+        this.condition = condition;
+    }
+
+    @Override
+    public boolean test(Object context) {
+        return !condition.test(context);
+    }
+
+    public static InvertedCondition fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("condition")) {
+            Origins.LOGGER.warn("Inverted condition '{}' is missing required 'condition' object", id);
+            return null;
+        }
+
+        JsonElement element = json.get("condition");
+        if (!element.isJsonObject()) {
+            Origins.LOGGER.warn("Inverted condition '{}' provided non-object 'condition' entry", id);
+            return null;
+        }
+
+        JsonObject childJson = GsonHelper.convertToJsonObject(element, "condition");
+        Optional<Condition<?>> nested = ConditionFactoryUtil.resolveNestedCondition(id, childJson, "condition", "condition");
+        if (nested.isEmpty()) {
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        Condition<Object> casted = (Condition<Object>) nested.get();
+        return new InvertedCondition(casted);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/OnFireCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/OnFireCondition.java
@@ -1,0 +1,27 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+
+import static io.github.apace100.origins.Origins.MOD_ID;
+
+/**
+ * Datapack condition that checks whether an entity is currently on fire.
+ */
+public final class OnFireCondition implements Condition<Entity> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(MOD_ID, "on_fire");
+
+    private OnFireCondition() {
+    }
+
+    @Override
+    public boolean test(Entity entity) {
+        return entity != null && entity.isOnFire();
+    }
+
+    public static OnFireCondition fromJson(ResourceLocation id, JsonObject json) {
+        return new OnFireCondition();
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/PassengerCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/PassengerCondition.java
@@ -1,0 +1,60 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.Entity;
+
+import java.util.Optional;
+
+/**
+ * Datapack condition that validates whether any passenger on an entity satisfies a nested condition.
+ */
+public final class PassengerCondition implements Condition<Entity> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "passenger");
+
+    private final Condition<Entity> passengerCondition;
+
+    private PassengerCondition(Condition<Entity> passengerCondition) {
+        this.passengerCondition = passengerCondition;
+    }
+
+    @Override
+    public boolean test(Entity entity) {
+        if (entity == null || passengerCondition == null) {
+            return false;
+        }
+        for (Entity passenger : entity.getPassengers()) {
+            if (passengerCondition.test(passenger)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static PassengerCondition fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("passenger")) {
+            Origins.LOGGER.warn("Passenger condition '{}' is missing required 'passenger' object", id);
+            return null;
+        }
+
+        JsonElement element = json.get("passenger");
+        if (!element.isJsonObject()) {
+            Origins.LOGGER.warn("Passenger condition '{}' provided non-object 'passenger' entry", id);
+            return null;
+        }
+
+        JsonObject passengerJson = GsonHelper.convertToJsonObject(element, "passenger");
+        Optional<Condition<?>> parsed = ConditionFactoryUtil.resolveNestedCondition(id, passengerJson, "passenger", "passenger");
+        if (parsed.isEmpty()) {
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        Condition<Entity> passengerCondition = (Condition<Entity>) parsed.get();
+        return new PassengerCondition(passengerCondition);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/SneakingCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/SneakingCondition.java
@@ -1,0 +1,27 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+
+import static io.github.apace100.origins.Origins.MOD_ID;
+
+/**
+ * Datapack condition that checks whether a player is sneaking.
+ */
+public final class SneakingCondition implements Condition<Player> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(MOD_ID, "sneaking");
+
+    private SneakingCondition() {
+    }
+
+    @Override
+    public boolean test(Player player) {
+        return player != null && player.isCrouching();
+    }
+
+    public static SneakingCondition fromJson(ResourceLocation id, JsonObject json) {
+        return new SneakingCondition();
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/registry/ConditionRegistry.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/registry/ConditionRegistry.java
@@ -3,12 +3,19 @@ package io.github.apace100.origins.power.condition.registry;
 import com.google.gson.JsonObject;
 import io.github.apace100.origins.power.condition.Condition;
 import io.github.apace100.origins.power.condition.impl.BiomeCondition;
+import io.github.apace100.origins.power.condition.impl.AllOfCondition;
+import io.github.apace100.origins.power.condition.impl.AnyOfCondition;
 import io.github.apace100.origins.power.condition.impl.BlockStateCondition;
 import io.github.apace100.origins.power.condition.impl.DamageSourceCondition;
 import io.github.apace100.origins.power.condition.impl.DimensionCondition;
 import io.github.apace100.origins.power.condition.impl.EquippedItemCondition;
 import io.github.apace100.origins.power.condition.impl.FluidCondition;
 import io.github.apace100.origins.power.condition.impl.FoodCondition;
+import io.github.apace100.origins.power.condition.impl.HealthCondition;
+import io.github.apace100.origins.power.condition.impl.InvertedCondition;
+import io.github.apace100.origins.power.condition.impl.OnFireCondition;
+import io.github.apace100.origins.power.condition.impl.PassengerCondition;
+import io.github.apace100.origins.power.condition.impl.SneakingCondition;
 import io.github.apace100.origins.power.condition.impl.TimeOfDayCondition;
 import io.github.apace100.origins.power.condition.impl.EntityCondition;
 import net.minecraft.resources.ResourceLocation;
@@ -47,6 +54,13 @@ public final class ConditionRegistry {
         register(FluidCondition.TYPE, FluidCondition::fromJson);
         register(FoodCondition.TYPE, FoodCondition::fromJson);
         register(EntityCondition.TYPE, EntityCondition::fromJson);
+        register(HealthCondition.TYPE, HealthCondition::fromJson);
+        register(OnFireCondition.TYPE, OnFireCondition::fromJson);
+        register(SneakingCondition.TYPE, SneakingCondition::fromJson);
+        register(PassengerCondition.TYPE, PassengerCondition::fromJson);
+        register(AllOfCondition.TYPE, AllOfCondition::fromJson);
+        register(AnyOfCondition.TYPE, AnyOfCondition::fromJson);
+        register(InvertedCondition.TYPE, InvertedCondition::fromJson);
     }
 
     /**


### PR DESCRIPTION
## Summary
- implement health, on_fire, sneaking, and passenger entity datapack conditions with recursive parsing
- add all_of, any_of, and inverted composite conditions plus shared nested-condition factory helper
- register the new factories and extend reload statistics/logging to report entity/composite condition counts

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68dd93693a688327ae10537a6ae4874e