### PR TITLE
Implement combat and environment datapack actions/conditions

### DIFF
--- a/src/main/java/io/github/apace100/origins/datapack/DataValidationLogger.java
+++ b/src/main/java/io/github/apace100/origins/datapack/DataValidationLogger.java
@@ -18,10 +18,10 @@ public final class DataValidationLogger extends SimplePreparableReloadListener<V
     @Override
     protected void apply(Void value, ResourceManager resourceManager, ProfilerFiller profiler) {
         ReloadStats stats = OriginsDataLoader.getLastReloadStats();
-        Origins.LOGGER.info("[Origins] Datapack reload summary: {} origins, {} powers, {} actions ({} effect / {} attribute / {} item), {} conditions ({} effect / {} attribute / {} entity / {} composite / {} item)",
+        Origins.LOGGER.info("[Origins] Datapack reload summary: {} origins, {} powers, {} actions ({} effect / {} attribute / {} item), {} conditions ({} effect / {} attribute / {} entity / {} composite / {} item / {} combat / {} environment)",
             stats.originsLoaded(), stats.powersLoaded(), stats.actionsLoaded(), stats.effectActionsLoaded(), stats.attributeActionsLoaded(), stats.itemActionsLoaded(),
             stats.conditionsLoaded(), stats.effectConditionsLoaded(), stats.attributeConditionsLoaded(), stats.entityConditionsLoaded(),
-            stats.compositeConditionsLoaded(), stats.itemConditionsLoaded());
+            stats.compositeConditionsLoaded(), stats.itemConditionsLoaded(), stats.combatConditionsLoaded(), stats.environmentConditionsLoaded());
         if (stats.skippedEntries() > 0) {
             Origins.LOGGER.info("[Origins] Datapack skipped {} entries during reload", stats.skippedEntries());
         }

--- a/src/main/java/io/github/apace100/origins/power/action/impl/HealAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/HealAction.java
@@ -1,0 +1,68 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.LivingEntity;
+
+/**
+ * Datapack action that heals a living entity by a fixed amount.
+ */
+public final class HealAction implements Action<LivingEntity> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "heal");
+    private static final Codec<HealAction> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.FLOAT.fieldOf("amount").forGetter(HealAction::amount)
+    ).apply(instance, HealAction::new));
+
+    private final float amount;
+
+    private HealAction(float amount) {
+        this.amount = amount;
+    }
+
+    private float amount() {
+        return amount;
+    }
+
+    @Override
+    public void execute(LivingEntity entity) {
+        if (entity == null || amount <= 0) {
+            return;
+        }
+        if (!(entity.level() instanceof ServerLevel)) {
+            return;
+        }
+        entity.heal(amount);
+    }
+
+    public static HealAction fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("amount")) {
+            Origins.LOGGER.warn("Heal action '{}' is missing required 'amount' field", id);
+            return null;
+        }
+
+        float amount;
+        try {
+            amount = GsonHelper.getAsFloat(json, "amount");
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Heal action '{}' has invalid 'amount': {}", id, exception.getMessage());
+            return null;
+        }
+
+        if (amount <= 0) {
+            Origins.LOGGER.warn("Heal action '{}' specified non-positive amount {}", id, amount);
+            return null;
+        }
+
+        return new HealAction(amount);
+    }
+
+    public static Codec<HealAction> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/KnockbackAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/KnockbackAction.java
@@ -1,0 +1,116 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Datapack action that applies a knockback impulse to an entity.
+ */
+public final class KnockbackAction implements Action<Entity> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "knockback");
+    private static final Codec<Vec3> DIRECTION_CODEC = Vec3.CODEC.flatXmap(KnockbackAction::validateDirection, KnockbackAction::validateDirection);
+    private static final Codec<KnockbackAction> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.FLOAT.fieldOf("strength").forGetter(KnockbackAction::strength),
+        DIRECTION_CODEC.fieldOf("direction").forGetter(KnockbackAction::direction)
+    ).apply(instance, KnockbackAction::new));
+
+    private final float strength;
+    private final Vec3 direction;
+
+    private KnockbackAction(float strength, Vec3 direction) {
+        this.strength = strength;
+        this.direction = direction.normalize();
+    }
+
+    private float strength() {
+        return strength;
+    }
+
+    private Vec3 direction() {
+        return direction;
+    }
+
+    @Override
+    public void execute(Entity entity) {
+        if (entity == null || strength <= 0) {
+            return;
+        }
+        if (!(entity.level() instanceof ServerLevel)) {
+            return;
+        }
+
+        Vec3 impulse = direction.scale(strength);
+        entity.push(impulse.x, impulse.y, impulse.z);
+    }
+
+    public static KnockbackAction fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("strength")) {
+            Origins.LOGGER.warn("Knockback action '{}' is missing required 'strength' field", id);
+            return null;
+        }
+        if (!json.has("direction")) {
+            Origins.LOGGER.warn("Knockback action '{}' is missing required 'direction' array", id);
+            return null;
+        }
+
+        float strength;
+        try {
+            strength = GsonHelper.getAsFloat(json, "strength");
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Knockback action '{}' has invalid 'strength': {}", id, exception.getMessage());
+            return null;
+        }
+
+        if (strength <= 0) {
+            Origins.LOGGER.warn("Knockback action '{}' specified non-positive strength {}", id, strength);
+            return null;
+        }
+
+        JsonArray array = GsonHelper.getAsJsonArray(json, "direction");
+        if (array.size() != 3) {
+            Origins.LOGGER.warn("Knockback action '{}' direction must contain exactly 3 elements", id);
+            return null;
+        }
+
+        double x;
+        double y;
+        double z;
+        try {
+            x = GsonHelper.convertToDouble(array.get(0), "direction[0]");
+            y = GsonHelper.convertToDouble(array.get(1), "direction[1]");
+            z = GsonHelper.convertToDouble(array.get(2), "direction[2]");
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Knockback action '{}' has invalid direction values: {}", id, exception.getMessage());
+            return null;
+        }
+
+        Vec3 direction = new Vec3(x, y, z);
+        if (direction.lengthSqr() == 0) {
+            Origins.LOGGER.warn("Knockback action '{}' specified a zero-length direction", id);
+            return null;
+        }
+
+        return new KnockbackAction(strength, direction);
+    }
+
+    public static Codec<KnockbackAction> codec() {
+        return CODEC;
+    }
+
+    private static DataResult<Vec3> validateDirection(Vec3 direction) {
+        if (direction == null || direction.lengthSqr() == 0) {
+            return DataResult.error(() -> "Knockback direction must not be zero");
+        }
+        return DataResult.success(direction.normalize());
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/ModifyDamageTakenAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/ModifyDamageTakenAction.java
@@ -1,0 +1,79 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+
+/**
+ * Datapack action which adjusts the most recent damage taken by a living entity.
+ */
+public final class ModifyDamageTakenAction implements Action<LivingEntity> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "modify_damage_taken");
+    private static final Codec<ModifyDamageTakenAction> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.FLOAT.fieldOf("amount").forGetter(ModifyDamageTakenAction::amount)
+    ).apply(instance, ModifyDamageTakenAction::new));
+
+    private final float amount;
+
+    private ModifyDamageTakenAction(float amount) {
+        this.amount = amount;
+    }
+
+    private float amount() {
+        return amount;
+    }
+
+    @Override
+    public void execute(LivingEntity entity) {
+        if (entity == null || amount == 0) {
+            return;
+        }
+        if (!(entity.level() instanceof ServerLevel level)) {
+            return;
+        }
+
+        if (amount < 0) {
+            entity.heal(-amount);
+            return;
+        }
+
+        DamageSource source = entity.getLastDamageSource();
+        if (source == null) {
+            source = level.damageSources().generic();
+        }
+        entity.hurt(source, amount);
+    }
+
+    public static ModifyDamageTakenAction fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("amount")) {
+            Origins.LOGGER.warn("Modify damage taken action '{}' is missing required 'amount' field", id);
+            return null;
+        }
+
+        float amount;
+        try {
+            amount = GsonHelper.getAsFloat(json, "amount");
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Modify damage taken action '{}' has invalid 'amount': {}", id, exception.getMessage());
+            return null;
+        }
+
+        if (amount == 0) {
+            Origins.LOGGER.warn("Modify damage taken action '{}' specified a zero modifier; ignoring", id);
+            return null;
+        }
+
+        return new ModifyDamageTakenAction(amount);
+    }
+
+    public static Codec<ModifyDamageTakenAction> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/PreventItemUseAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/PreventItemUseAction.java
@@ -1,0 +1,128 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Datapack action that cancels item usage for a configured hand and item.
+ */
+public final class PreventItemUseAction implements Action<Player> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "prevent_item_use");
+    private static final Codec<PreventItemUseAction> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.STRING.comapFlatMap(PreventItemUseAction::decodeHand, PreventItemUseAction::encodeHand).fieldOf("slot").forGetter(action -> action.hand),
+        ResourceLocation.CODEC.fieldOf("item").forGetter(PreventItemUseAction::itemId)
+    ).apply(instance, PreventItemUseAction::fromCodec));
+
+    private final InteractionHand hand;
+    private final ResourceLocation itemId;
+    private final Item item;
+
+    private PreventItemUseAction(InteractionHand hand, ResourceLocation itemId, Item item) {
+        this.hand = hand;
+        this.itemId = itemId;
+        this.item = item;
+    }
+
+    private ResourceLocation itemId() {
+        return itemId;
+    }
+
+    @Override
+    public void execute(Player player) {
+        if (player == null) {
+            return;
+        }
+        if (!(player.level() instanceof ServerLevel)) {
+            return;
+        }
+
+        ItemStack held = player.getItemInHand(hand);
+        if (!held.is(item)) {
+            return;
+        }
+
+        if (player.isUsingItem() && player.getUsedItemHand() == hand) {
+            player.stopUsingItem();
+        }
+    }
+
+    public static PreventItemUseAction fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("slot")) {
+            Origins.LOGGER.warn("Prevent item use action '{}' is missing required 'slot' field", id);
+            return null;
+        }
+        if (!json.has("item")) {
+            Origins.LOGGER.warn("Prevent item use action '{}' is missing required 'item' field", id);
+            return null;
+        }
+
+        String rawSlot = GsonHelper.getAsString(json, "slot");
+        Optional<InteractionHand> parsedHand = parseHand(rawSlot);
+        if (parsedHand.isEmpty()) {
+            Origins.LOGGER.warn("Prevent item use action '{}' specified unsupported slot '{}'", id, rawSlot);
+            return null;
+        }
+
+        String rawItem = GsonHelper.getAsString(json, "item");
+        ResourceLocation itemId;
+        try {
+            itemId = ResourceLocation.parse(rawItem);
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Prevent item use action '{}' has invalid item id '{}': {}", id, rawItem, exception.getMessage());
+            return null;
+        }
+
+        Optional<Item> resolved = BuiltInRegistries.ITEM.getOptional(itemId);
+        if (resolved.isEmpty()) {
+            Origins.LOGGER.warn("Prevent item use action '{}' references unknown item {}", id, itemId);
+            return null;
+        }
+
+        return new PreventItemUseAction(parsedHand.get(), itemId, resolved.get());
+    }
+
+    public static Codec<PreventItemUseAction> codec() {
+        return CODEC;
+    }
+
+    private static DataResult<InteractionHand> decodeHand(String value) {
+        return parseHand(value)
+            .map(DataResult::success)
+            .orElseGet(() -> DataResult.error(() -> "Unsupported hand value: " + value));
+    }
+
+    private static String encodeHand(InteractionHand hand) {
+        return hand == InteractionHand.OFF_HAND ? "offhand" : "mainhand";
+    }
+
+    private static Optional<InteractionHand> parseHand(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        return switch (value.toLowerCase(Locale.ROOT)) {
+            case "mainhand", "main_hand", "main" -> Optional.of(InteractionHand.MAIN_HAND);
+            case "offhand", "off_hand", "off" -> Optional.of(InteractionHand.OFF_HAND);
+            default -> Optional.empty();
+        };
+    }
+
+    private static PreventItemUseAction fromCodec(InteractionHand hand, ResourceLocation itemId) {
+        Item item = BuiltInRegistries.ITEM.get(itemId);
+        return new PreventItemUseAction(hand, itemId, item);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/registry/ActionRegistry.java
+++ b/src/main/java/io/github/apace100/origins/power/action/registry/ActionRegistry.java
@@ -15,11 +15,15 @@ import io.github.apace100.origins.power.action.impl.ExecuteCommandAction;
 import io.github.apace100.origins.power.action.impl.ExplosionAction;
 import io.github.apace100.origins.power.action.impl.GiveItemAction;
 import io.github.apace100.origins.power.action.impl.GrantAdvancementAction;
+import io.github.apace100.origins.power.action.impl.HealAction;
 import io.github.apace100.origins.power.action.impl.ItemAction;
 import io.github.apace100.origins.power.action.impl.LightningAction;
 import io.github.apace100.origins.power.action.impl.ModifyAttributeAction;
+import io.github.apace100.origins.power.action.impl.ModifyDamageTakenAction;
+import io.github.apace100.origins.power.action.impl.KnockbackAction;
 import io.github.apace100.origins.power.action.impl.ParticleAction;
 import io.github.apace100.origins.power.action.impl.PlaySoundAction;
+import io.github.apace100.origins.power.action.impl.PreventItemUseAction;
 import io.github.apace100.origins.power.action.impl.ReplaceEquippedItemAction;
 import io.github.apace100.origins.power.action.impl.ResetAttributeAction;
 import io.github.apace100.origins.power.action.impl.SetBlockAction;
@@ -75,6 +79,10 @@ public final class ActionRegistry {
         register(ConsumeItemAction.TYPE, ConsumeItemAction::fromJson);
         register(ReplaceEquippedItemAction.TYPE, ReplaceEquippedItemAction::fromJson);
         register(DamageItemAction.TYPE, DamageItemAction::fromJson);
+        register(ModifyDamageTakenAction.TYPE, ModifyDamageTakenAction::fromJson);
+        register(HealAction.TYPE, HealAction::fromJson);
+        register(KnockbackAction.TYPE, KnockbackAction::fromJson);
+        register(PreventItemUseAction.TYPE, PreventItemUseAction::fromJson);
     }
 
     /**

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/AttackerCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/AttackerCondition.java
@@ -1,0 +1,96 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.Dynamic;
+import com.mojang.serialization.JsonOps;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+
+import java.util.Optional;
+
+/**
+ * Datapack condition that delegates to a nested entity condition for the attacker.
+ */
+public final class AttackerCondition implements Condition<DamageSource> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "attacker");
+    private static final Codec<JsonObject> JSON_OBJECT_CODEC = Codec.PASSTHROUGH.flatXmap(dynamic -> {
+        JsonElement element = dynamic.convert(JsonOps.INSTANCE).getValue();
+        if (!element.isJsonObject()) {
+            return DataResult.error(() -> "Expected attacker condition entity_condition to be an object");
+        }
+        return DataResult.success(element.getAsJsonObject());
+    }, json -> DataResult.success(new Dynamic<>(JsonOps.INSTANCE, json)));
+    private static final Codec<AttackerCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        JSON_OBJECT_CODEC.fieldOf("entity_condition").forGetter(AttackerCondition::definition)
+    ).apply(instance, AttackerCondition::fromCodec));
+
+    private final Condition<Entity> attackerCondition;
+    private final JsonObject definition;
+
+    private AttackerCondition(Condition<Entity> attackerCondition, JsonObject definition) {
+        this.attackerCondition = attackerCondition;
+        this.definition = definition;
+    }
+
+    private JsonObject definition() {
+        return definition;
+    }
+
+    @Override
+    public boolean test(DamageSource source) {
+        if (source == null || attackerCondition == null) {
+            return false;
+        }
+        Entity attacker = source.getEntity();
+        if (attacker == null) {
+            return false;
+        }
+        return attackerCondition.test(attacker);
+    }
+
+    public static AttackerCondition fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("entity_condition")) {
+            Origins.LOGGER.warn("Attacker condition '{}' is missing required 'entity_condition' object", id);
+            return null;
+        }
+
+        JsonElement element = json.get("entity_condition");
+        if (!element.isJsonObject()) {
+            Origins.LOGGER.warn("Attacker condition '{}' provided non-object 'entity_condition'", id);
+            return null;
+        }
+
+        JsonObject nestedJson = element.getAsJsonObject();
+        Optional<Condition<?>> nested = ConditionFactoryUtil.resolveNestedCondition(id, nestedJson, "entity_condition", "entity_condition");
+        if (nested.isEmpty()) {
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        Condition<Entity> attackerCondition = (Condition<Entity>) nested.get();
+        return new AttackerCondition(attackerCondition, nestedJson.deepCopy());
+    }
+
+    public static Codec<AttackerCondition> codec() {
+        return CODEC;
+    }
+
+    private static AttackerCondition fromCodec(JsonObject nested) {
+        ResourceLocation tempId = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "attacker/codec");
+        Optional<Condition<?>> resolved = ConditionFactoryUtil.resolveNestedCondition(tempId, nested, "entity_condition", "entity_condition");
+        if (resolved.isEmpty()) {
+            return new AttackerCondition(context -> false, nested.deepCopy());
+        }
+        @SuppressWarnings("unchecked")
+        Condition<Entity> attackerCondition = (Condition<Entity>) resolved.get();
+        return new AttackerCondition(attackerCondition, nested.deepCopy());
+    }
+
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/LightLevelCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/LightLevelCondition.java
@@ -1,0 +1,113 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.level.LightLayer;
+
+import java.util.Optional;
+
+/**
+ * Datapack condition that checks the block light level at a configured position.
+ */
+public final class LightLevelCondition implements Condition<ServerLevel> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "light_level");
+    private static final Codec<LightLevelCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.INT.optionalFieldOf("min", 0).forGetter(LightLevelCondition::minLight),
+        Codec.INT.optionalFieldOf("max", 15).forGetter(LightLevelCondition::maxLight),
+        BlockPos.CODEC.optionalFieldOf("pos").forGetter(LightLevelCondition::position)
+    ).apply(instance, LightLevelCondition::new));
+
+    private final int minLight;
+    private final int maxLight;
+    private final Optional<BlockPos> position;
+
+    private LightLevelCondition(int minLight, int maxLight, Optional<BlockPos> position) {
+        this.minLight = minLight;
+        this.maxLight = maxLight;
+        this.position = position;
+    }
+
+    private int minLight() {
+        return minLight;
+    }
+
+    private int maxLight() {
+        return maxLight;
+    }
+
+    private Optional<BlockPos> position() {
+        return position;
+    }
+
+    @Override
+    public boolean test(ServerLevel level) {
+        if (level == null) {
+            return false;
+        }
+        BlockPos pos = position.orElse(level.getSharedSpawnPos());
+        int light = level.getBrightness(LightLayer.BLOCK, pos);
+        return light >= minLight && light <= maxLight;
+    }
+
+    public static LightLevelCondition fromJson(ResourceLocation id, JsonObject json) {
+        int min = 0;
+        int max = 15;
+        if (json.has("min")) {
+            try {
+                min = GsonHelper.getAsInt(json, "min");
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Light level condition '{}' has invalid 'min': {}", id, exception.getMessage());
+                return null;
+            }
+        }
+        if (json.has("max")) {
+            try {
+                max = GsonHelper.getAsInt(json, "max");
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Light level condition '{}' has invalid 'max': {}", id, exception.getMessage());
+                return null;
+            }
+        }
+
+        if (min < 0 || max > 15) {
+            Origins.LOGGER.warn("Light level condition '{}' values must be between 0 and 15 (found {}-{})", id, min, max);
+            return null;
+        }
+        if (max < min) {
+            Origins.LOGGER.warn("Light level condition '{}' has max ({}) smaller than min ({})", id, max, min);
+            return null;
+        }
+
+        Optional<BlockPos> position = Optional.empty();
+        if (json.has("pos")) {
+            JsonArray array = GsonHelper.getAsJsonArray(json, "pos");
+            if (array.size() != 3) {
+                Origins.LOGGER.warn("Light level condition '{}' position must contain exactly 3 elements", id);
+                return null;
+            }
+            try {
+                int x = GsonHelper.convertToInt(array.get(0), "pos[0]");
+                int y = GsonHelper.convertToInt(array.get(1), "pos[1]");
+                int z = GsonHelper.convertToInt(array.get(2), "pos[2]");
+                position = Optional.of(new BlockPos(x, y, z));
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Light level condition '{}' has invalid position values: {}", id, exception.getMessage());
+                return null;
+            }
+        }
+
+        return new LightLevelCondition(min, max, position);
+    }
+
+    public static Codec<LightLevelCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/RecentDamageCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/RecentDamageCondition.java
@@ -1,0 +1,85 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * Datapack condition that checks if a living entity has taken damage recently.
+ */
+public final class RecentDamageCondition implements Condition<LivingEntity> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "recent_damage");
+    private static final Map<LivingEntity, Long> LAST_DAMAGE_TICKS = Collections.synchronizedMap(new WeakHashMap<>());
+    private static final Codec<RecentDamageCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.INT.fieldOf("seconds").forGetter(RecentDamageCondition::seconds)
+    ).apply(instance, RecentDamageCondition::new));
+
+    private final int seconds;
+
+    private RecentDamageCondition(int seconds) {
+        this.seconds = seconds;
+    }
+
+    private int seconds() {
+        return seconds;
+    }
+
+    @Override
+    public boolean test(LivingEntity entity) {
+        if (entity == null || seconds <= 0) {
+            return false;
+        }
+        Level level = entity.level();
+        if (level == null) {
+            return false;
+        }
+
+        long gameTime = level.getGameTime();
+        if (entity.getLastDamageSource() != null) {
+            LAST_DAMAGE_TICKS.put(entity, gameTime);
+        }
+
+        Long lastTick = LAST_DAMAGE_TICKS.get(entity);
+        if (lastTick == null) {
+            return false;
+        }
+        long threshold = seconds * 20L;
+        return gameTime - lastTick <= threshold;
+    }
+
+    public static RecentDamageCondition fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("seconds")) {
+            Origins.LOGGER.warn("Recent damage condition '{}' is missing required 'seconds' field", id);
+            return null;
+        }
+
+        int seconds;
+        try {
+            seconds = GsonHelper.getAsInt(json, "seconds");
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Recent damage condition '{}' has invalid 'seconds': {}", id, exception.getMessage());
+            return null;
+        }
+
+        if (seconds <= 0) {
+            Origins.LOGGER.warn("Recent damage condition '{}' specified non-positive seconds {}", id, seconds);
+            return null;
+        }
+
+        return new RecentDamageCondition(seconds);
+    }
+
+    public static Codec<RecentDamageCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/WeatherCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/WeatherCondition.java
@@ -1,0 +1,76 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.GsonHelper;
+
+import java.util.Optional;
+
+/**
+ * Datapack condition that checks the current weather state.
+ */
+public final class WeatherCondition implements Condition<ServerLevel> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "weather");
+    private static final Codec<WeatherCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.BOOL.optionalFieldOf("raining").forGetter(condition -> condition.raining),
+        Codec.BOOL.optionalFieldOf("thundering").forGetter(condition -> condition.thundering)
+    ).apply(instance, WeatherCondition::new));
+
+    private final Optional<Boolean> raining;
+    private final Optional<Boolean> thundering;
+
+    private WeatherCondition(Optional<Boolean> raining, Optional<Boolean> thundering) {
+        this.raining = raining;
+        this.thundering = thundering;
+    }
+
+    @Override
+    public boolean test(ServerLevel level) {
+        if (level == null) {
+            return false;
+        }
+        if (raining.isPresent() && level.isRaining() != raining.get()) {
+            return false;
+        }
+        return thundering.isEmpty() || level.isThundering() == thundering.get();
+    }
+
+    public static WeatherCondition fromJson(ResourceLocation id, JsonObject json) {
+        Optional<Boolean> raining = Optional.empty();
+        Optional<Boolean> thundering = Optional.empty();
+
+        if (json.has("raining")) {
+            try {
+                raining = Optional.of(GsonHelper.getAsBoolean(json, "raining"));
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Weather condition '{}' has invalid 'raining' value: {}", id, exception.getMessage());
+                return null;
+            }
+        }
+
+        if (json.has("thundering")) {
+            try {
+                thundering = Optional.of(GsonHelper.getAsBoolean(json, "thundering"));
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Weather condition '{}' has invalid 'thundering' value: {}", id, exception.getMessage());
+                return null;
+            }
+        }
+
+        if (raining.isEmpty() && thundering.isEmpty()) {
+            Origins.LOGGER.warn("Weather condition '{}' must specify at least one of 'raining' or 'thundering'", id);
+            return null;
+        }
+
+        return new WeatherCondition(raining, thundering);
+    }
+
+    public static Codec<WeatherCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/YLevelCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/YLevelCondition.java
@@ -1,0 +1,80 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.Entity;
+
+/**
+ * Datapack condition that checks if an entity is within a configured Y-level range.
+ */
+public final class YLevelCondition implements Condition<Entity> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "y_level");
+    private static final Codec<YLevelCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codec.DOUBLE.optionalFieldOf("min", Double.NEGATIVE_INFINITY).forGetter(YLevelCondition::minY),
+        Codec.DOUBLE.optionalFieldOf("max", Double.POSITIVE_INFINITY).forGetter(YLevelCondition::maxY)
+    ).apply(instance, YLevelCondition::new));
+
+    private final double minY;
+    private final double maxY;
+
+    private YLevelCondition(double minY, double maxY) {
+        this.minY = minY;
+        this.maxY = maxY;
+    }
+
+    private double minY() {
+        return minY;
+    }
+
+    private double maxY() {
+        return maxY;
+    }
+
+    @Override
+    public boolean test(Entity entity) {
+        if (entity == null) {
+            return false;
+        }
+        double y = entity.getY();
+        return y >= minY && y <= maxY;
+    }
+
+    public static YLevelCondition fromJson(ResourceLocation id, JsonObject json) {
+        double min = Double.NEGATIVE_INFINITY;
+        double max = Double.POSITIVE_INFINITY;
+
+        if (json.has("min")) {
+            try {
+                min = GsonHelper.getAsDouble(json, "min");
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Y-level condition '{}' has invalid 'min': {}", id, exception.getMessage());
+                return null;
+            }
+        }
+
+        if (json.has("max")) {
+            try {
+                max = GsonHelper.getAsDouble(json, "max");
+            } catch (IllegalArgumentException exception) {
+                Origins.LOGGER.warn("Y-level condition '{}' has invalid 'max': {}", id, exception.getMessage());
+                return null;
+            }
+        }
+
+        if (max < min) {
+            Origins.LOGGER.warn("Y-level condition '{}' has max ({}) smaller than min ({})", id, max, min);
+            return null;
+        }
+
+        return new YLevelCondition(min, max);
+    }
+
+    public static Codec<YLevelCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/registry/ConditionRegistry.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/registry/ConditionRegistry.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import io.github.apace100.origins.power.condition.Condition;
 import io.github.apace100.origins.power.condition.impl.AllOfCondition;
 import io.github.apace100.origins.power.condition.impl.AnyOfCondition;
+import io.github.apace100.origins.power.condition.impl.AttackerCondition;
 import io.github.apace100.origins.power.condition.impl.AttributeCondition;
 import io.github.apace100.origins.power.condition.impl.BiomeCondition;
 import io.github.apace100.origins.power.condition.impl.BlockStateCondition;
@@ -14,15 +15,19 @@ import io.github.apace100.origins.power.condition.impl.EquippedItemCondition;
 import io.github.apace100.origins.power.condition.impl.FluidCondition;
 import io.github.apace100.origins.power.condition.impl.FoodCondition;
 import io.github.apace100.origins.power.condition.impl.HealthCondition;
+import io.github.apace100.origins.power.condition.impl.LightLevelCondition;
 import io.github.apace100.origins.power.condition.impl.ItemDurabilityCondition;
 import io.github.apace100.origins.power.condition.impl.ItemEnchantmentCondition;
 import io.github.apace100.origins.power.condition.impl.ItemTagCondition;
 import io.github.apace100.origins.power.condition.impl.InvertedCondition;
 import io.github.apace100.origins.power.condition.impl.OnFireCondition;
 import io.github.apace100.origins.power.condition.impl.PassengerCondition;
+import io.github.apace100.origins.power.condition.impl.RecentDamageCondition;
 import io.github.apace100.origins.power.condition.impl.SneakingCondition;
 import io.github.apace100.origins.power.condition.impl.TimeOfDayCondition;
 import io.github.apace100.origins.power.condition.impl.EntityCondition;
+import io.github.apace100.origins.power.condition.impl.WeatherCondition;
+import io.github.apace100.origins.power.condition.impl.YLevelCondition;
 import net.minecraft.resources.ResourceLocation;
 
 import java.util.Collections;
@@ -71,6 +76,11 @@ public final class ConditionRegistry {
         register(ItemEnchantmentCondition.TYPE, ItemEnchantmentCondition::fromJson);
         register(ItemDurabilityCondition.TYPE, ItemDurabilityCondition::fromJson);
         register(ItemTagCondition.TYPE, ItemTagCondition::fromJson);
+        register(AttackerCondition.TYPE, AttackerCondition::fromJson);
+        register(RecentDamageCondition.TYPE, RecentDamageCondition::fromJson);
+        register(LightLevelCondition.TYPE, LightLevelCondition::fromJson);
+        register(WeatherCondition.TYPE, WeatherCondition::fromJson);
+        register(YLevelCondition.TYPE, YLevelCondition::fromJson);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add combat-focused datapack actions (modify_damage_taken, heal, knockback, prevent_item_use) and register them
- implement attacker, recent_damage, light_level, weather, and y_level datapack conditions with codecs and registry hooks
- extend datapack loader metrics to categorize combat and environment conditions in logs and validation output

## Testing
- `./gradlew compileJava`


------
https://chatgpt.com/codex/tasks/task_e_68dd9ead00888327b24aca67fb5297d3