### PR TITLE
Implement food, block, and projectile datapack actions and conditions

### DIFF
--- a/src/main/java/io/github/apace100/origins/datapack/DataValidationLogger.java
+++ b/src/main/java/io/github/apace100/origins/datapack/DataValidationLogger.java
@@ -18,10 +18,12 @@ public final class DataValidationLogger extends SimplePreparableReloadListener<V
     @Override
     protected void apply(Void value, ResourceManager resourceManager, ProfilerFiller profiler) {
         ReloadStats stats = OriginsDataLoader.getLastReloadStats();
-        Origins.LOGGER.info("[Origins] Datapack reload summary: {} origins, {} powers, {} actions ({} effect / {} attribute / {} item), {} conditions ({} effect / {} attribute / {} entity / {} composite / {} item / {} combat / {} environment)",
+        Origins.LOGGER.info("[Origins] Datapack reload summary: {} origins, {} powers, {} actions ({} effect / {} attribute / {} item / {} food / {} block / {} projectile), {} conditions ({} effect / {} attribute / {} entity / {} composite / {} item / {} block / {} projectile / {} combat / {} environment)",
             stats.originsLoaded(), stats.powersLoaded(), stats.actionsLoaded(), stats.effectActionsLoaded(), stats.attributeActionsLoaded(), stats.itemActionsLoaded(),
+            stats.foodActionsLoaded(), stats.blockActionsLoaded(), stats.projectileActionsLoaded(),
             stats.conditionsLoaded(), stats.effectConditionsLoaded(), stats.attributeConditionsLoaded(), stats.entityConditionsLoaded(),
-            stats.compositeConditionsLoaded(), stats.itemConditionsLoaded(), stats.combatConditionsLoaded(), stats.environmentConditionsLoaded());
+            stats.compositeConditionsLoaded(), stats.itemConditionsLoaded(), stats.blockConditionsLoaded(), stats.projectileConditionsLoaded(),
+            stats.combatConditionsLoaded(), stats.environmentConditionsLoaded());
         if (stats.skippedEntries() > 0) {
             Origins.LOGGER.info("[Origins] Datapack skipped {} entries during reload", stats.skippedEntries());
         }

--- a/src/main/java/io/github/apace100/origins/datapack/OriginsDataLoader.java
+++ b/src/main/java/io/github/apace100/origins/datapack/OriginsDataLoader.java
@@ -26,6 +26,11 @@ import io.github.apace100.origins.power.action.impl.ConsumeItemAction;
 import io.github.apace100.origins.power.action.impl.DamageItemAction;
 import io.github.apace100.origins.power.action.impl.GiveItemAction;
 import io.github.apace100.origins.power.action.impl.ModifyAttributeAction;
+import io.github.apace100.origins.power.action.impl.ModifyFoodAction;
+import io.github.apace100.origins.power.action.impl.ModifyProjectileAction;
+import io.github.apace100.origins.power.action.impl.PreventBlockUseAction;
+import io.github.apace100.origins.power.action.impl.PreventFoodAction;
+import io.github.apace100.origins.power.action.impl.PreventProjectileAction;
 import io.github.apace100.origins.power.action.impl.ReplaceEquippedItemAction;
 import io.github.apace100.origins.power.action.impl.ResetAttributeAction;
 import io.github.apace100.origins.power.action.registry.ActionRegistry;
@@ -48,6 +53,8 @@ import io.github.apace100.origins.power.condition.impl.ItemTagCondition;
 import io.github.apace100.origins.power.condition.impl.LightLevelCondition;
 import io.github.apace100.origins.power.condition.impl.OnFireCondition;
 import io.github.apace100.origins.power.condition.impl.PassengerCondition;
+import io.github.apace100.origins.power.condition.impl.PreventBlockUseCondition;
+import io.github.apace100.origins.power.condition.impl.ProjectileCondition;
 import io.github.apace100.origins.power.condition.impl.RecentDamageCondition;
 import io.github.apace100.origins.power.condition.impl.SneakingCondition;
 import io.github.apace100.origins.power.condition.registry.ConditionRegistry;
@@ -143,12 +150,17 @@ public final class OriginsDataLoader extends SimpleJsonResourceReloadListener {
         int effectActionCount = countEffectActions(actions);
         int attributeActionCount = countAttributeActions(actions);
         int itemActionCount = countItemActions(actions);
+        int foodActionCount = countFoodActions(actions);
+        int blockActionCount = countBlockActions(actions);
+        int projectileActionCount = countProjectileActions(actions);
 
         Map<ResourceLocation, Condition<?>> conditions = decodeConditions(pendingConditionJson);
         ConditionRegistry.setAll(conditions);
         int effectConditionCount = countEffectConditions(conditions);
         int attributeConditionCount = countAttributeConditions(conditions);
         int itemConditionCount = countItemConditions(conditions);
+        int blockConditionCount = countBlockConditions(conditions);
+        int projectileConditionCount = countProjectileConditions(conditions);
         int combatConditionCount = countCombatConditions(conditions);
         int environmentConditionCount = countEnvironmentConditions(conditions);
 
@@ -166,20 +178,23 @@ public final class OriginsDataLoader extends SimpleJsonResourceReloadListener {
         int compositeConditionCount = countCompositeConditions(conditions);
         int totalSkipped = skippedOrigins + skippedPowers + skippedActions + skippedConditions;
         LAST_STATS = new ReloadStats(origins.size(), powers.size(), actions.size(), conditions.size(), effectActionCount,
-            attributeActionCount, itemActionCount, effectConditionCount, attributeConditionCount, entityConditionCount,
-            compositeConditionCount, itemConditionCount, combatConditionCount, environmentConditionCount, totalSkipped,
+            attributeActionCount, itemActionCount, foodActionCount, blockActionCount, projectileActionCount,
+            effectConditionCount, attributeConditionCount, entityConditionCount, compositeConditionCount, itemConditionCount,
+            blockConditionCount, projectileConditionCount, combatConditionCount, environmentConditionCount, totalSkipped,
             unknownTypes);
 
         if (totalSkipped > 0) {
-            Origins.LOGGER.info("Loaded {} origins, {} powers, {} actions ({} effect / {} attribute / {} item), and {} conditions ({} effect / {} attribute / {} entity / {} composite / {} item / {} combat / {} environment) from datapacks ({} entries skipped)",
+            Origins.LOGGER.info("Loaded {} origins, {} powers, {} actions ({} effect / {} attribute / {} item / {} food / {} block / {} projectile), and {} conditions ({} effect / {} attribute / {} entity / {} composite / {} item / {} block / {} projectile / {} combat / {} environment) from datapacks ({} entries skipped)",
                 origins.size(), powers.size(), actions.size(), effectActionCount, attributeActionCount, itemActionCount,
+                foodActionCount, blockActionCount, projectileActionCount,
                 conditions.size(), effectConditionCount, attributeConditionCount, entityConditionCount, compositeConditionCount,
-                itemConditionCount, combatConditionCount, environmentConditionCount, totalSkipped);
+                itemConditionCount, blockConditionCount, projectileConditionCount, combatConditionCount, environmentConditionCount, totalSkipped);
         } else {
-            Origins.LOGGER.info("Loaded {} origins, {} powers, {} actions ({} effect / {} attribute / {} item), and {} conditions ({} effect / {} attribute / {} entity / {} composite / {} item / {} combat / {} environment) from datapacks",
+            Origins.LOGGER.info("Loaded {} origins, {} powers, {} actions ({} effect / {} attribute / {} item / {} food / {} block / {} projectile), and {} conditions ({} effect / {} attribute / {} entity / {} composite / {} item / {} block / {} projectile / {} combat / {} environment) from datapacks",
                 origins.size(), powers.size(), actions.size(), effectActionCount, attributeActionCount, itemActionCount,
+                foodActionCount, blockActionCount, projectileActionCount,
                 conditions.size(), effectConditionCount, attributeConditionCount, entityConditionCount, compositeConditionCount,
-                itemConditionCount, combatConditionCount, environmentConditionCount);
+                itemConditionCount, blockConditionCount, projectileConditionCount, combatConditionCount, environmentConditionCount);
         }
     }
 
@@ -257,6 +272,24 @@ public final class OriginsDataLoader extends SimpleJsonResourceReloadListener {
             .count();
     }
 
+    private static int countFoodActions(Map<ResourceLocation, Action<?>> actions) {
+        return (int) actions.values().stream()
+            .filter(action -> action instanceof ModifyFoodAction || action instanceof PreventFoodAction)
+            .count();
+    }
+
+    private static int countBlockActions(Map<ResourceLocation, Action<?>> actions) {
+        return (int) actions.values().stream()
+            .filter(action -> action instanceof PreventBlockUseAction)
+            .count();
+    }
+
+    private static int countProjectileActions(Map<ResourceLocation, Action<?>> actions) {
+        return (int) actions.values().stream()
+            .filter(action -> action instanceof ModifyProjectileAction || action instanceof PreventProjectileAction)
+            .count();
+    }
+
     private static int countEffectConditions(Map<ResourceLocation, Condition<?>> conditions) {
         return (int) conditions.values().stream()
             .filter(condition -> condition instanceof EffectActiveCondition)
@@ -282,6 +315,18 @@ public final class OriginsDataLoader extends SimpleJsonResourceReloadListener {
             .filter(condition -> condition instanceof ItemEnchantmentCondition
                 || condition instanceof ItemDurabilityCondition
                 || condition instanceof ItemTagCondition)
+            .count();
+    }
+
+    private static int countBlockConditions(Map<ResourceLocation, Condition<?>> conditions) {
+        return (int) conditions.values().stream()
+            .filter(condition -> condition instanceof PreventBlockUseCondition)
+            .count();
+    }
+
+    private static int countProjectileConditions(Map<ResourceLocation, Condition<?>> conditions) {
+        return (int) conditions.values().stream()
+            .filter(condition -> condition instanceof ProjectileCondition)
             .count();
     }
 
@@ -312,6 +357,7 @@ public final class OriginsDataLoader extends SimpleJsonResourceReloadListener {
             || condition instanceof SneakingCondition
             || condition instanceof PassengerCondition
             || condition instanceof RecentDamageCondition
+            || condition instanceof ProjectileCondition
             || condition instanceof YLevelCondition;
     }
 
@@ -594,18 +640,23 @@ public final class OriginsDataLoader extends SimpleJsonResourceReloadListener {
         int effectActionsLoaded,
         int attributeActionsLoaded,
         int itemActionsLoaded,
+        int foodActionsLoaded,
+        int blockActionsLoaded,
+        int projectileActionsLoaded,
         int effectConditionsLoaded,
         int attributeConditionsLoaded,
         int entityConditionsLoaded,
         int compositeConditionsLoaded,
         int itemConditionsLoaded,
+        int blockConditionsLoaded,
+        int projectileConditionsLoaded,
         int combatConditionsLoaded,
         int environmentConditionsLoaded,
         int skippedEntries,
         List<ResourceLocation> unknownTypes
     ) {
         static ReloadStats empty() {
-            return new ReloadStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, List.of());
+            return new ReloadStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, List.of());
         }
     }
 

--- a/src/main/java/io/github/apace100/origins/power/action/impl/ModifyFoodAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/ModifyFoodAction.java
@@ -1,0 +1,101 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.food.FoodData;
+
+/**
+ * Datapack action that modifies a player's hunger and saturation values.
+ */
+public final class ModifyFoodAction implements Action<Player> {
+    private static final int MIN_DELTA = -20;
+    private static final int MAX_DELTA = 20;
+    private static final float MIN_SATURATION_DELTA = -20.0F;
+    private static final float MAX_SATURATION_DELTA = 20.0F;
+
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "modify_food");
+    private static final Codec<ModifyFoodAction> CODEC = RecordCodecBuilder.<ModifyFoodAction>create(instance -> instance.group(
+        Codec.INT.optionalFieldOf("hunger", 0).forGetter(ModifyFoodAction::hungerDelta),
+        Codec.FLOAT.optionalFieldOf("saturation", 0.0F).forGetter(ModifyFoodAction::saturationDelta)
+    ).apply(instance, (hunger, saturation) -> new ModifyFoodAction(hunger, saturation))).flatXmap(ModifyFoodAction::validate, ModifyFoodAction::validate);
+
+    private final int hungerDelta;
+    private final float saturationDelta;
+
+    private ModifyFoodAction(int hungerDelta, float saturationDelta) {
+        this.hungerDelta = hungerDelta;
+        this.saturationDelta = saturationDelta;
+    }
+
+    private int hungerDelta() {
+        return hungerDelta;
+    }
+
+    private float saturationDelta() {
+        return saturationDelta;
+    }
+
+    @Override
+    public void execute(Player player) {
+        if (player == null) {
+            return;
+        }
+
+        FoodData data = player.getFoodData();
+        if (hungerDelta != 0) {
+            int adjusted = Mth.clamp(data.getFoodLevel() + hungerDelta, 0, 20);
+            data.setFoodLevel(adjusted);
+        }
+
+        if (saturationDelta != 0.0F) {
+            float cappedMax = Math.max(0.0F, (float) data.getFoodLevel());
+            float adjusted = Mth.clamp(data.getSaturationLevel() + saturationDelta, 0.0F, cappedMax);
+            data.setSaturation(adjusted);
+        }
+    }
+
+    public static ModifyFoodAction fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("hunger") && !json.has("saturation")) {
+            Origins.LOGGER.warn("Modify food action '{}' is missing both 'hunger' and 'saturation' fields", id);
+            return null;
+        }
+
+        int hunger = json.has("hunger") ? GsonHelper.getAsInt(json, "hunger") : 0;
+        float saturation = json.has("saturation") ? GsonHelper.getAsFloat(json, "saturation") : 0.0F;
+
+        ModifyFoodAction action = new ModifyFoodAction(hunger, saturation);
+        DataResult<ModifyFoodAction> validation = validate(action);
+        return validation.resultOrPartial(message -> Origins.LOGGER.warn("Modify food action '{}' is invalid: {}", id, message))
+            .orElse(null);
+    }
+
+    public static Codec<ModifyFoodAction> codec() {
+        return CODEC;
+    }
+
+    private static DataResult<ModifyFoodAction> validate(ModifyFoodAction action) {
+        if (action.hungerDelta == 0 && action.saturationDelta == 0.0F) {
+            return DataResult.error(() -> "modify_food action must specify a non-zero hunger or saturation change");
+        }
+        if (action.hungerDelta < MIN_DELTA || action.hungerDelta > MAX_DELTA) {
+            return DataResult.error(() -> "hunger change " + action.hungerDelta + " is outside the allowed range ["
+                + MIN_DELTA + ", " + MAX_DELTA + "]");
+        }
+        if (!Float.isFinite(action.saturationDelta)) {
+            return DataResult.error(() -> "saturation change must be a finite number");
+        }
+        if (action.saturationDelta < MIN_SATURATION_DELTA || action.saturationDelta > MAX_SATURATION_DELTA) {
+            return DataResult.error(() -> "saturation change " + action.saturationDelta
+                + " is outside the allowed range [" + MIN_SATURATION_DELTA + ", " + MAX_SATURATION_DELTA + "]");
+        }
+        return DataResult.success(action);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/ModifyProjectileAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/ModifyProjectileAction.java
@@ -1,0 +1,98 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.projectile.AbstractArrow;
+import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.Optional;
+
+/**
+ * Datapack action that scales projectile velocity and base damage.
+ */
+public final class ModifyProjectileAction implements Action<Entity> {
+    private static final double MIN_MULTIPLIER = 0.0D;
+
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "modify_projectile");
+    private static final Codec<ModifyProjectileAction> CODEC = RecordCodecBuilder.<ModifyProjectileAction>create(instance -> instance.group(
+        Codec.DOUBLE.optionalFieldOf("speed_multiplier", 1.0D).forGetter(ModifyProjectileAction::speedMultiplier),
+        Codec.DOUBLE.optionalFieldOf("damage_multiplier", 1.0D).forGetter(ModifyProjectileAction::damageMultiplier)
+    ).apply(instance, (speed, damage) -> new ModifyProjectileAction(speed, damage))).flatXmap(ModifyProjectileAction::validate, ModifyProjectileAction::validate);
+
+    private final double speedMultiplier;
+    private final double damageMultiplier;
+    private final Optional<ResourceLocation> sourceId;
+
+    private ModifyProjectileAction(double speedMultiplier, double damageMultiplier) {
+        this(Optional.empty(), speedMultiplier, damageMultiplier);
+    }
+
+    private ModifyProjectileAction(Optional<ResourceLocation> sourceId, double speedMultiplier, double damageMultiplier) {
+        this.sourceId = sourceId;
+        this.speedMultiplier = speedMultiplier;
+        this.damageMultiplier = damageMultiplier;
+    }
+
+    private double speedMultiplier() {
+        return speedMultiplier;
+    }
+
+    private double damageMultiplier() {
+        return damageMultiplier;
+    }
+
+    @Override
+    public void execute(Entity entity) {
+        if (!(entity instanceof Projectile projectile)) {
+            Origins.LOGGER.warn("Modify projectile action '{}' attempted to run on non-projectile entity {}",
+                sourceId.map(ResourceLocation::toString).orElse("<untracked>"), entity);
+            return;
+        }
+
+        if (speedMultiplier != 1.0D) {
+            Vec3 velocity = projectile.getDeltaMovement();
+            projectile.setDeltaMovement(velocity.scale(speedMultiplier));
+            projectile.hasImpulse = true;
+        }
+
+        if (damageMultiplier != 1.0D) {
+            if (projectile instanceof AbstractArrow arrow) {
+                arrow.setBaseDamage(arrow.getBaseDamage() * damageMultiplier);
+            } else {
+                Origins.LOGGER.warn("Modify projectile action '{}' cannot adjust damage for entity type {}",
+                    sourceId.map(ResourceLocation::toString).orElse("<untracked>"), entity.getType());
+            }
+        }
+    }
+
+    public static ModifyProjectileAction fromJson(ResourceLocation id, JsonObject json) {
+        double speed = json.has("speed_multiplier") ? GsonHelper.getAsDouble(json, "speed_multiplier") : 1.0D;
+        double damage = json.has("damage_multiplier") ? GsonHelper.getAsDouble(json, "damage_multiplier") : 1.0D;
+        ModifyProjectileAction action = new ModifyProjectileAction(Optional.of(id), speed, damage);
+        DataResult<ModifyProjectileAction> validation = validate(action);
+        return validation.resultOrPartial(message -> Origins.LOGGER.warn("Modify projectile action '{}' is invalid: {}", id, message))
+            .orElse(null);
+    }
+
+    public static Codec<ModifyProjectileAction> codec() {
+        return CODEC;
+    }
+
+    private static DataResult<ModifyProjectileAction> validate(ModifyProjectileAction action) {
+        if (!Double.isFinite(action.speedMultiplier) || action.speedMultiplier <= MIN_MULTIPLIER) {
+            return DataResult.error(() -> "speed multiplier must be greater than " + MIN_MULTIPLIER);
+        }
+        if (!Double.isFinite(action.damageMultiplier) || action.damageMultiplier <= MIN_MULTIPLIER) {
+            return DataResult.error(() -> "damage multiplier must be greater than " + MIN_MULTIPLIER);
+        }
+        return DataResult.success(action);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/PreventBlockUseAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/PreventBlockUseAction.java
@@ -1,0 +1,125 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+
+import java.util.Optional;
+
+/**
+ * Datapack action that cancels block interactions against a configured block.
+ */
+public final class PreventBlockUseAction implements Action<Player> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "prevent_block_use");
+    private static final ThreadLocal<BlockInteraction> CONTEXT = new ThreadLocal<>();
+    private static final Codec<PreventBlockUseAction> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        BuiltInRegistries.BLOCK.byNameCodec().fieldOf("block").forGetter(PreventBlockUseAction::block)
+    ).apply(instance, PreventBlockUseAction::new));
+
+    private final Block block;
+
+    private PreventBlockUseAction(Block block) {
+        this.block = block;
+    }
+
+    public Block block() {
+        return block;
+    }
+
+    @Override
+    public void execute(Player player) {
+        if (player == null) {
+            return;
+        }
+
+        Level level = player.level();
+        if (level == null) {
+            return;
+        }
+
+        Optional<BlockInteraction> interaction = Optional.ofNullable(CONTEXT.get())
+            .or(() -> resolveFromRaycast(player, level));
+        if (interaction.isEmpty()) {
+            return;
+        }
+
+        BlockInteraction target = interaction.get();
+        BlockState state = target.state();
+        if (!state.is(block)) {
+            return;
+        }
+
+        if (player instanceof ServerPlayer serverPlayer) {
+            serverPlayer.connection.send(new ClientboundBlockUpdatePacket(target.pos(), state));
+        }
+        player.swing(InteractionHand.MAIN_HAND, true);
+        player.closeContainer();
+    }
+
+    public static PreventBlockUseAction fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("block")) {
+            Origins.LOGGER.warn("Prevent block use action '{}' is missing required 'block' field", id);
+            return null;
+        }
+
+        String raw = GsonHelper.getAsString(json, "block");
+        ResourceLocation blockId;
+        try {
+            blockId = ResourceLocation.parse(raw);
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Prevent block use action '{}' has invalid block id '{}': {}", id, raw, exception.getMessage());
+            return null;
+        }
+
+        Optional<Block> resolved = BuiltInRegistries.BLOCK.getOptional(blockId);
+        if (resolved.isEmpty()) {
+            Origins.LOGGER.warn("Prevent block use action '{}' references unknown block '{}'", id, blockId);
+            return null;
+        }
+
+        return new PreventBlockUseAction(resolved.get());
+    }
+
+    public static Codec<PreventBlockUseAction> codec() {
+        return CODEC;
+    }
+
+    public static void withContext(BlockState state, BlockPos pos, Runnable runnable) {
+        CONTEXT.set(new BlockInteraction(state, pos));
+        try {
+            runnable.run();
+        } finally {
+            CONTEXT.remove();
+        }
+    }
+
+    private static Optional<BlockInteraction> resolveFromRaycast(Player player, Level level) {
+        HitResult hitResult = player.pick(5.0D, 0.0F, false);
+        if (!(hitResult instanceof BlockHitResult blockHit)) {
+            return Optional.empty();
+        }
+
+        BlockPos pos = blockHit.getBlockPos();
+        BlockState state = level.getBlockState(pos);
+        return Optional.of(new BlockInteraction(state, pos));
+    }
+
+    private record BlockInteraction(BlockState state, BlockPos pos) {
+    }
+
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/PreventFoodAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/PreventFoodAction.java
@@ -1,0 +1,104 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Optional;
+
+/**
+ * Datapack action that stops players from eating a configured item.
+ */
+public final class PreventFoodAction implements Action<Player> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "prevent_food");
+    private static final Codec<PreventFoodAction> CODEC = RecordCodecBuilder.<PreventFoodAction>create(instance -> instance.group(
+        ResourceLocation.CODEC.fieldOf("item").forGetter(PreventFoodAction::itemId)
+    ).apply(instance, itemId -> fromCodec(itemId))).flatXmap(PreventFoodAction::validateCodec, PreventFoodAction::validateCodec);
+
+    private final ResourceLocation itemId;
+    private final Item item;
+
+    private PreventFoodAction(ResourceLocation itemId, Item item) {
+        this.itemId = itemId;
+        this.item = item;
+    }
+
+    private ResourceLocation itemId() {
+        return itemId;
+    }
+
+    @Override
+    public void execute(Player player) {
+        if (player == null) {
+            return;
+        }
+        if (!(player.level() instanceof ServerLevel)) {
+            return;
+        }
+
+        boolean matched = false;
+        for (InteractionHand hand : InteractionHand.values()) {
+            ItemStack stack = player.getItemInHand(hand);
+            if (!stack.is(item)) {
+                continue;
+            }
+            matched = true;
+            if (player.isUsingItem() && player.getUsedItemHand() == hand) {
+                player.stopUsingItem();
+            }
+        }
+
+        if (matched && player instanceof ServerPlayer serverPlayer) {
+            serverPlayer.getCooldowns().addCooldown(item, 5);
+        }
+    }
+
+    public static PreventFoodAction fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("item")) {
+            Origins.LOGGER.warn("Prevent food action '{}' is missing required 'item' field", id);
+            return null;
+        }
+
+        String raw = GsonHelper.getAsString(json, "item");
+        ResourceLocation itemId;
+        try {
+            itemId = ResourceLocation.parse(raw);
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Prevent food action '{}' has invalid item id '{}': {}", id, raw, exception.getMessage());
+            return null;
+        }
+
+        Optional<Item> resolved = BuiltInRegistries.ITEM.getOptional(itemId);
+        if (resolved.isEmpty()) {
+            Origins.LOGGER.warn("Prevent food action '{}' references unknown item '{}'", id, itemId);
+            return null;
+        }
+
+        return new PreventFoodAction(itemId, resolved.get());
+    }
+
+    public static Codec<PreventFoodAction> codec() {
+        return CODEC;
+    }
+
+    private static PreventFoodAction fromCodec(ResourceLocation itemId) {
+        Item item = BuiltInRegistries.ITEM.get(itemId);
+        return new PreventFoodAction(itemId, item);
+    }
+
+    private static DataResult<PreventFoodAction> validateCodec(PreventFoodAction action) {
+        return DataResult.success(action);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/impl/PreventProjectileAction.java
+++ b/src/main/java/io/github/apace100/origins/power/action/impl/PreventProjectileAction.java
@@ -1,0 +1,117 @@
+package io.github.apace100.origins.power.action.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.action.Action;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ProjectileItem;
+import net.minecraft.world.item.ProjectileWeaponItem;
+import net.minecraft.world.item.TridentItem;
+
+import java.util.Optional;
+
+/**
+ * Datapack action that cancels projectile launches from a configured weapon.
+ */
+public final class PreventProjectileAction implements Action<Player> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "prevent_projectile");
+    private static final Codec<PreventProjectileAction> CODEC = RecordCodecBuilder.<PreventProjectileAction>create(instance -> instance.group(
+        ResourceLocation.CODEC.fieldOf("item").forGetter(PreventProjectileAction::itemId)
+    ).apply(instance, itemId -> fromCodec(itemId))).flatXmap(PreventProjectileAction::validateCodec, PreventProjectileAction::validateCodec);
+
+    private final ResourceLocation itemId;
+    private final Item item;
+
+    private PreventProjectileAction(ResourceLocation itemId, Item item) {
+        this.itemId = itemId;
+        this.item = item;
+    }
+
+    private ResourceLocation itemId() {
+        return itemId;
+    }
+
+    @Override
+    public void execute(Player player) {
+        if (player == null) {
+            return;
+        }
+        if (!(player.level() instanceof ServerLevel)) {
+            return;
+        }
+
+        boolean matched = false;
+        for (InteractionHand hand : InteractionHand.values()) {
+            ItemStack stack = player.getItemInHand(hand);
+            if (!stack.is(item)) {
+                continue;
+            }
+            matched = true;
+            if (player.isUsingItem() && player.getUsedItemHand() == hand) {
+                player.stopUsingItem();
+            }
+        }
+
+        if (matched && player instanceof ServerPlayer serverPlayer) {
+            serverPlayer.getCooldowns().addCooldown(item, 5);
+        }
+    }
+
+    public static PreventProjectileAction fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("item")) {
+            Origins.LOGGER.warn("Prevent projectile action '{}' is missing required 'item' field", id);
+            return null;
+        }
+
+        String raw = GsonHelper.getAsString(json, "item");
+        ResourceLocation itemId;
+        try {
+            itemId = ResourceLocation.parse(raw);
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Prevent projectile action '{}' has invalid item id '{}': {}", id, raw, exception.getMessage());
+            return null;
+        }
+
+        Optional<Item> resolved = BuiltInRegistries.ITEM.getOptional(itemId);
+        if (resolved.isEmpty()) {
+            Origins.LOGGER.warn("Prevent projectile action '{}' references unknown item '{}'", id, itemId);
+            return null;
+        }
+
+        Item item = resolved.get();
+        if (!(item instanceof ProjectileWeaponItem) && !(item instanceof ProjectileItem) && !(item instanceof TridentItem)) {
+            Origins.LOGGER.warn("Prevent projectile action '{}' references non-projectile weapon '{}'", id, itemId);
+            return null;
+        }
+
+        return new PreventProjectileAction(itemId, item);
+    }
+
+    public static Codec<PreventProjectileAction> codec() {
+        return CODEC;
+    }
+
+    private static PreventProjectileAction fromCodec(ResourceLocation itemId) {
+        Item item = BuiltInRegistries.ITEM.get(itemId);
+        return new PreventProjectileAction(itemId, item);
+    }
+
+    private static DataResult<PreventProjectileAction> validateCodec(PreventProjectileAction action) {
+        if (!(action.item instanceof ProjectileWeaponItem) && !(action.item instanceof ProjectileItem)
+            && !(action.item instanceof TridentItem)) {
+            return DataResult.error(() -> "Item " + action.itemId + " is not a projectile weapon");
+        }
+        return DataResult.success(action);
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/action/registry/ActionRegistry.java
+++ b/src/main/java/io/github/apace100/origins/power/action/registry/ActionRegistry.java
@@ -20,10 +20,15 @@ import io.github.apace100.origins.power.action.impl.ItemAction;
 import io.github.apace100.origins.power.action.impl.LightningAction;
 import io.github.apace100.origins.power.action.impl.ModifyAttributeAction;
 import io.github.apace100.origins.power.action.impl.ModifyDamageTakenAction;
+import io.github.apace100.origins.power.action.impl.ModifyFoodAction;
+import io.github.apace100.origins.power.action.impl.ModifyProjectileAction;
 import io.github.apace100.origins.power.action.impl.KnockbackAction;
 import io.github.apace100.origins.power.action.impl.ParticleAction;
 import io.github.apace100.origins.power.action.impl.PlaySoundAction;
+import io.github.apace100.origins.power.action.impl.PreventBlockUseAction;
+import io.github.apace100.origins.power.action.impl.PreventFoodAction;
 import io.github.apace100.origins.power.action.impl.PreventItemUseAction;
+import io.github.apace100.origins.power.action.impl.PreventProjectileAction;
 import io.github.apace100.origins.power.action.impl.ReplaceEquippedItemAction;
 import io.github.apace100.origins.power.action.impl.ResetAttributeAction;
 import io.github.apace100.origins.power.action.impl.SetBlockAction;
@@ -77,12 +82,17 @@ public final class ActionRegistry {
         register(ModifyAttributeAction.TYPE, ModifyAttributeAction::fromJson);
         register(ResetAttributeAction.TYPE, ResetAttributeAction::fromJson);
         register(ConsumeItemAction.TYPE, ConsumeItemAction::fromJson);
+        register(ModifyFoodAction.TYPE, ModifyFoodAction::fromJson);
+        register(PreventFoodAction.TYPE, PreventFoodAction::fromJson);
         register(ReplaceEquippedItemAction.TYPE, ReplaceEquippedItemAction::fromJson);
         register(DamageItemAction.TYPE, DamageItemAction::fromJson);
         register(ModifyDamageTakenAction.TYPE, ModifyDamageTakenAction::fromJson);
         register(HealAction.TYPE, HealAction::fromJson);
         register(KnockbackAction.TYPE, KnockbackAction::fromJson);
         register(PreventItemUseAction.TYPE, PreventItemUseAction::fromJson);
+        register(PreventBlockUseAction.TYPE, PreventBlockUseAction::fromJson);
+        register(ModifyProjectileAction.TYPE, ModifyProjectileAction::fromJson);
+        register(PreventProjectileAction.TYPE, PreventProjectileAction::fromJson);
     }
 
     /**

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/PreventBlockUseCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/PreventBlockUseCondition.java
@@ -1,0 +1,67 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.Optional;
+
+/**
+ * Datapack condition that evaluates whether a block state matches a configured block type.
+ */
+public final class PreventBlockUseCondition implements Condition<BlockState> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "prevent_block_use");
+    private static final Codec<PreventBlockUseCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        BuiltInRegistries.BLOCK.byNameCodec().fieldOf("block").forGetter(PreventBlockUseCondition::block)
+    ).apply(instance, PreventBlockUseCondition::new));
+
+    private final Block block;
+
+    private PreventBlockUseCondition(Block block) {
+        this.block = block;
+    }
+
+    private Block block() {
+        return block;
+    }
+
+    @Override
+    public boolean test(BlockState state) {
+        return state != null && state.is(block);
+    }
+
+    public static PreventBlockUseCondition fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("block")) {
+            Origins.LOGGER.warn("Prevent block use condition '{}' is missing required 'block' field", id);
+            return null;
+        }
+
+        String raw = GsonHelper.getAsString(json, "block");
+        ResourceLocation blockId;
+        try {
+            blockId = ResourceLocation.parse(raw);
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Prevent block use condition '{}' has invalid block id '{}': {}", id, raw, exception.getMessage());
+            return null;
+        }
+
+        Optional<Block> resolved = BuiltInRegistries.BLOCK.getOptional(blockId);
+        if (resolved.isEmpty()) {
+            Origins.LOGGER.warn("Prevent block use condition '{}' references unknown block '{}'", id, blockId);
+            return null;
+        }
+
+        return new PreventBlockUseCondition(resolved.get());
+    }
+
+    public static Codec<PreventBlockUseCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/impl/ProjectileCondition.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/impl/ProjectileCondition.java
@@ -1,0 +1,79 @@
+package io.github.apace100.origins.power.condition.impl;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.power.condition.Condition;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.projectile.Projectile;
+
+import java.util.Optional;
+
+/**
+ * Datapack condition that checks whether the supplied entity is a projectile of a configured type.
+ */
+public final class ProjectileCondition implements Condition<Entity> {
+    public static final ResourceLocation TYPE = ResourceLocation.fromNamespaceAndPath(Origins.MOD_ID, "projectile");
+    private static final Codec<ProjectileCondition> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        BuiltInRegistries.ENTITY_TYPE.byNameCodec().fieldOf("entity").forGetter(ProjectileCondition::entityType)
+    ).apply(instance, ProjectileCondition::new));
+
+    private final EntityType<?> entityType;
+    private final Optional<ResourceLocation> sourceId;
+
+    private ProjectileCondition(EntityType<?> entityType) {
+        this(Optional.empty(), entityType);
+    }
+
+    private ProjectileCondition(Optional<ResourceLocation> sourceId, EntityType<?> entityType) {
+        this.sourceId = sourceId;
+        this.entityType = entityType;
+    }
+
+    private EntityType<?> entityType() {
+        return entityType;
+    }
+
+    @Override
+    public boolean test(Entity entity) {
+        if (!(entity instanceof Projectile)) {
+            Origins.LOGGER.warn("Projectile condition '{}' evaluated a non-projectile entity {}",
+                sourceId.map(ResourceLocation::toString).orElse("<untracked>"), entity);
+            return false;
+        }
+        return entity.getType() == entityType;
+    }
+
+    public static ProjectileCondition fromJson(ResourceLocation id, JsonObject json) {
+        if (!json.has("entity")) {
+            Origins.LOGGER.warn("Projectile condition '{}' is missing required 'entity' field", id);
+            return null;
+        }
+
+        String raw = GsonHelper.getAsString(json, "entity");
+        ResourceLocation entityId;
+        try {
+            entityId = ResourceLocation.parse(raw);
+        } catch (IllegalArgumentException exception) {
+            Origins.LOGGER.warn("Projectile condition '{}' has invalid entity id '{}': {}", id, raw, exception.getMessage());
+            return null;
+        }
+
+        Optional<EntityType<?>> resolved = BuiltInRegistries.ENTITY_TYPE.getOptional(entityId);
+        if (resolved.isEmpty()) {
+            Origins.LOGGER.warn("Projectile condition '{}' references unknown entity '{}'", id, entityId);
+            return null;
+        }
+
+        return new ProjectileCondition(Optional.of(id), resolved.get());
+    }
+
+    public static Codec<ProjectileCondition> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/power/condition/registry/ConditionRegistry.java
+++ b/src/main/java/io/github/apace100/origins/power/condition/registry/ConditionRegistry.java
@@ -22,6 +22,8 @@ import io.github.apace100.origins.power.condition.impl.ItemTagCondition;
 import io.github.apace100.origins.power.condition.impl.InvertedCondition;
 import io.github.apace100.origins.power.condition.impl.OnFireCondition;
 import io.github.apace100.origins.power.condition.impl.PassengerCondition;
+import io.github.apace100.origins.power.condition.impl.PreventBlockUseCondition;
+import io.github.apace100.origins.power.condition.impl.ProjectileCondition;
 import io.github.apace100.origins.power.condition.impl.RecentDamageCondition;
 import io.github.apace100.origins.power.condition.impl.SneakingCondition;
 import io.github.apace100.origins.power.condition.impl.TimeOfDayCondition;
@@ -81,6 +83,8 @@ public final class ConditionRegistry {
         register(LightLevelCondition.TYPE, LightLevelCondition::fromJson);
         register(WeatherCondition.TYPE, WeatherCondition::fromJson);
         register(YLevelCondition.TYPE, YLevelCondition::fromJson);
+        register(PreventBlockUseCondition.TYPE, PreventBlockUseCondition::fromJson);
+        register(ProjectileCondition.TYPE, ProjectileCondition::fromJson);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add modify/prevent food actions plus block-use and projectile datapack hooks
- register new actions/conditions and update reload logging with additional category counts
- introduce projectile and block-use conditions with validation helpers

## Testing
- `./gradlew compileJava`


------
https://chatgpt.com/codex/tasks/task_e_68ddb231579883279412af8a8c37106a