### PR TITLE
Fix command registration event bus usage

### DIFF
--- a/src/main/java/io/github/apace100/origins/OriginsNeoForge.java
+++ b/src/main/java/io/github/apace100/origins/OriginsNeoForge.java
@@ -33,7 +33,7 @@ public final class OriginsNeoForge {
         ModActions.register(modBus);
         ModConditions.register(modBus);
         ModNetworking.register(modBus);
-        ModCommands.register(modBus);
+        ModCommands.register();
         ModDataGen.register(modBus);
 
         OriginPowerManager.init();

--- a/src/main/java/io/github/apace100/origins/common/commands/ModCommands.java
+++ b/src/main/java/io/github/apace100/origins/common/commands/ModCommands.java
@@ -16,15 +16,15 @@ import net.minecraft.commands.arguments.ResourceLocationArgument;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
-import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 
 public final class ModCommands {
     private ModCommands() {
     }
 
-    public static void register(IEventBus modBus) {
-        modBus.addListener(ModCommands::onRegisterCommands);
+    public static void register() {
+        NeoForge.EVENT_BUS.addListener(ModCommands::onRegisterCommands);
     }
 
     private static void onRegisterCommands(RegisterCommandsEvent event) {

--- a/src/main/java/io/github/apace100/origins/events/CommandEvents.java
+++ b/src/main/java/io/github/apace100/origins/events/CommandEvents.java
@@ -6,7 +6,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 
-@EventBusSubscriber(modid = Origins.MOD_ID)
+@EventBusSubscriber(modid = Origins.MOD_ID, bus = EventBusSubscriber.Bus.GAME)
 public final class CommandEvents {
     @SubscribeEvent
     public static void registerCommands(RegisterCommandsEvent e) {


### PR DESCRIPTION
## Summary
- register ModCommands on the NeoForge EVENT_BUS instead of the mod bus to avoid RegisterCommandsEvent crashes
- mark the annotation-based CommandEvents handler to listen on the game/NeoForge bus

## Testing
- ./gradlew clean build

------
https://chatgpt.com/codex/tasks/task_e_68df35453d808327b99bf9952eb7b235