### PR TITLE
Add mixin validation and placeholder guard to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Compile with strict lint and warnings
         run: ./gradlew clean build --warning-mode all --console=plain --stacktrace
 
+      - name: Run Mixin Compatibility Validation
+        run: ./gradlew validateMixinCompatLevel
+
+      - name: Run Placeholder Guard
+        run: python3 scripts/assert-no-placeholders.py
+
       - name: Upload Problems Report
         if: always()
         uses: actions/upload-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,18 @@ Thank you for your interest in contributing to Origins NeoTest! This project rel
    ./gradlew clean build --warning-mode all
    ```
    This command surfaces all Gradle deprecation warnings and enforces the compiler lint settings configured in `build.gradle`.
-3. Resolve any warnings produced by the build. Pull requests that surface compiler or Gradle warnings will be rejected by continuous integration.
+3. Validate mixin compatibility and ensure no placeholder textures are present before pushing:
+   ```bash
+   ./gradlew validateMixinCompatLevel
+   python3 scripts/assert-no-placeholders.py
+   ```
+   These commands ensure that mixin definitions declare `JAVA_21` compatibility and that no temporary placeholder PNGs slip into commits.
+4. Resolve any warnings or validation failures locally. Pull requests that surface compiler warnings, mixin compatibility issues, or placeholder assets will be rejected by continuous integration.
 
 ## Submitting Your Pull Request
 
 - Provide clear descriptions of the changes made and the testing performed.
 - Keep your branch up to date with the main branch to minimize merge conflicts.
-- CI will automatically run `./gradlew clean build --warning-mode all --console=plain --stacktrace` and upload a Gradle problems report artifact for review. Builds that produce warnings or deprecations will fail.
+- CI will automatically run `./gradlew clean build --warning-mode all --console=plain --stacktrace`, `./gradlew validateMixinCompatLevel`, and `python3 scripts/assert-no-placeholders.py`, uploading a Gradle problems report artifact for review. Builds that produce warnings, violate mixin compatibility, or commit placeholder assets will fail.
 
 We appreciate your contributions and attention to build quality!

--- a/scripts/assert-no-placeholders.py
+++ b/scripts/assert-no-placeholders.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Fail the build if placeholder PNG assets are present in the repository.
+
+The guard intentionally runs in CI as well as locally to ensure that temporary
+textures do not ship in releases. It scans the repository for PNG files whose
+name contains the word "placeholder" (case-insensitive) outside of ignored
+build directories.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+IGNORED_DIR_NAMES = {".git", "build", ".gradle", "runs", "out", "dist"}
+
+
+def should_ignore(path: Path) -> bool:
+    """Return True if *path* is located within an ignored directory."""
+
+    return any(part in IGNORED_DIR_NAMES for part in path.parts)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    violations: list[Path] = []
+
+    for png in repo_root.rglob("*.png"):
+        if should_ignore(png.relative_to(repo_root)):
+            continue
+
+        if "placeholder" in png.stem.lower() or "placeholder" in png.name.lower():
+            violations.append(png.relative_to(repo_root))
+
+    if violations:
+        print("Placeholder PNG assets detected:")
+        for file_path in violations:
+            print(f" - {file_path}")
+        print(
+            "Please replace these textures with finalized assets before committing "
+            "or add them to the ignore list if they are generated."
+        )
+        return 1
+
+    print("No placeholder PNG assets detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add mixin compatibility validation and placeholder guard steps to the CI workflow
- document the new checks in CONTRIBUTING.md for local development
- add a helper script to fail the build when placeholder PNGs are committed

## Testing
- python3 scripts/assert-no-placeholders.py

------
https://chatgpt.com/codex/tasks/task_e_68e1fe1d6ba48327875783a872a6185b