### PR TITLE
Document parity audit workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,34 @@ The file exposes the following options for the bundled powers:
 ## Datapack parity auditing
 
 The port ships with a parity audit flow that compares the Fabric Origins/Apoli datapacks
-against the NeoForge implementation. To generate a report:
+against the NeoForge implementation. Use the following workflow to produce the audit
+artifacts:
 
 1. Copy the official Origins and Apoli datapacks into the instance's `datapacks/`
-   directory.
-2. Open `config/origins-common.toml` and set `debugAudit = true` to surface detailed
-   warnings during reload.
-3. Run `/reload` or invoke `/origins debug parity` in-game/console to build a
-   `debug/parity_report.json` file containing implemented identifiers, missing
-   action/condition/power IDs, and the datapack files or origins that reference them.
-4. Inspect the generated JSON to identify parity gaps and follow the console logs for a
-   summary of implemented versus missing categories.
+   directory (see [`datapacks/README.md`](datapacks/README.md) for download links).
+2. Enable parity logging by either setting `debugAudit = true` under the `[debug]`
+   section of `config/origins-common.toml` or passing `-Dorigins.debug_audit=true` on the
+   JVM command line when launching the dev run configuration.
+3. Run `/reload` once in-game/console so the `OriginsDataLoader` indexes every datapack
+   entry and reports implemented versus missing identifiers to the log.
+4. Generate the detailed parity report with:
+
+   ```bash
+   /origins debug parity
+   ```
+
+   This writes `debug/parity_report.json`, listing every discovered action, condition,
+   and power along with any unimplemented IDs.
+5. Produce the actionable TODO checklist with:
+
+   ```bash
+   /origins debug todo
+   ```
+
+   The command creates `debug/parity_todo.json` which groups missing IDs by datapack
+   context (origin, power, or file) to help prioritise follow-up work.
+6. Inspect both JSON files and cross-reference the missing identifiers against the Fabric
+   Origins/Apoli documentation to schedule implementation tasks.
 
 ## Updating Minecraft or NeoForge versions
 

--- a/datapacks/README.md
+++ b/datapacks/README.md
@@ -1,0 +1,8 @@
+# Fabric datapacks for parity audits
+
+Place the official Fabric **Origins** and **Apoli** datapacks in this directory before running the NeoForge parity audit. You can obtain the latest datapack zips from the respective mod releases:
+
+* Origins: https://github.com/apace100/origins/releases
+* Apoli: https://github.com/apace100/apoli/releases
+
+Download each archive, extract the contained datapack folder (usually named `origins` or `apoli`), and copy it here so the game can load it as part of the `/reload` command. The parity tooling reads every pack present in this directory when `/origins debug parity` or `/origins debug todo` is executed.


### PR DESCRIPTION
## Summary
- add a datapacks/ README that points to the official Origins and Apoli downloads used for parity checks
- expand the main README with a step-by-step parity audit workflow, including the debug parity/todo commands and configuration toggle

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e2010181b48327b19d7cee565a390b