### PR TITLE
Add runAudit Gradle task for parity audit workflow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,15 @@ dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
 }
 
+runs {
+    runAudit {
+        workingDirectory project.file('run')
+        taskName 'runAudit'
+        args '--username', 'DevAudit'
+        property 'origins.debugAudit', 'true'
+    }
+}
+
 sourceSets {
     main {
         resources {

--- a/datapacks/README.md
+++ b/datapacks/README.md
@@ -1,8 +1,8 @@
 # Fabric datapacks for parity audits
 
-Place the official Fabric **Origins** and **Apoli** datapacks in this directory before running the NeoForge parity audit. You can obtain the latest datapack zips from the respective mod releases:
+Place the official Fabric **Origins** and **Apoli** datapacks inside `run/datapacks/` before running the NeoForge parity audit. This `datapacks/` folder documents the process and provides download links so they are easy to locate when preparing an audit run. You can obtain the latest datapack zips from the respective mod releases:
 
 * Origins: https://github.com/apace100/origins/releases
 * Apoli: https://github.com/apace100/apoli/releases
 
-Download each archive, extract the contained datapack folder (usually named `origins` or `apoli`), and copy it here so the game can load it as part of the `/reload` command. The parity tooling reads every pack present in this directory when `/origins debug parity` or `/origins debug todo` is executed.
+Download each archive, extract the contained datapack folder (usually named `origins` or `apoli`), and copy it into `run/datapacks/` so the game can load it as part of the `/reload` command. The parity tooling reads every pack present in that directory when `/origins debug parity` or `/origins debug todo` is executed.

--- a/reports/parity/README.md
+++ b/reports/parity/README.md
@@ -1,0 +1,11 @@
+# Parity audit reports
+
+The automated parity audit run copies its JSON output into this directory so the results
+can be checked into source control:
+
+* `parity_report.json` – Comprehensive list of datapack elements and their parity status.
+* `parity_todo.json` – Condensed backlog grouped by context for follow-up work.
+
+After running `./gradlew runAudit` in the development environment and executing the
+in-game `/origins debug parity` and `/origins debug todo` commands, copy the generated
+files from `run/debug/` into this folder before committing changes.

--- a/src/main/java/io/github/apace100/origins/config/OriginsConfig.java
+++ b/src/main/java/io/github/apace100/origins/config/OriginsConfig.java
@@ -73,6 +73,11 @@ public final class OriginsConfig {
     }
 
     private static OriginsConfigValues readValues() {
+        boolean debugAuditOverride = Boolean.getBoolean("origins.debugAudit");
+        boolean debugAudit = DEBUG_AUDIT.get();
+        if (debugAuditOverride) {
+            debugAudit = true;
+        }
         return new OriginsConfigValues(
             new OriginsConfigValues.Phantom(
                 PHANTOM.hungerDrainIntervalTicks.get(),
@@ -98,7 +103,7 @@ public final class OriginsConfig {
                 ELYTRIAN.confinedSpaceChecks.get()
             ),
             new OriginsConfigValues.Shulk(SHULK.chestArmorAllowed.get()),
-            DEBUG_AUDIT.get()
+            debugAudit
         );
     }
 


### PR DESCRIPTION
## Summary
- add a dedicated `runAudit` Gradle run configuration that enables audit mode by default
- allow the `origins.debugAudit` system property to force parity logging regardless of config values
- document datapack placement, audit workflow, and report collection locations

## Testing
- not run (Minecraft client launch is not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e201dc44a883279411f1be55de3ae4