### PR TITLE
Add zip-based Fabric datapack import to runAudit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 out/
 runs/
 generated/
+external/fabric-origins-zips/
 
 # IDE
 .idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,20 @@ Thank you for your interest in contributing to Origins NeoTest! This project rel
    These commands ensure that mixin definitions declare `JAVA_21` compatibility and that no temporary placeholder PNGs slip into commits.
 4. Resolve any warnings or validation failures locally. Pull requests that surface compiler warnings, mixin compatibility issues, or placeholder assets will be rejected by continuous integration.
 
+## Refreshing the Fabric datapack snapshot
+
+Auditing parity changes requires the latest Fabric Origins datapack. Drop the newest zip into `external/fabric-origins-zips/` and run the audit configuration:
+
+```powershell
+# Drop latest zip into external/fabric-origins-zips/
+.\gradlew.bat runAudit
+/reload
+/origins debug parity
+/origins debug todo
+```
+
+Only the most recent zip in the folder is extracted. Gradle unpacks the datapack into `run/datapacks/origins-fabric/` automatically before the client launches.
+
 ## Submitting Your Pull Request
 
 - Provide clear descriptions of the changes made and the testing performed.

--- a/README.md
+++ b/README.md
@@ -71,29 +71,27 @@ The file exposes the following options for the bundled powers:
 The NeoForge port ships with a dedicated Gradle run configuration that enables the parity
 audit tooling and collects reports for review. Follow this workflow to produce an audit:
 
-1. Download the Fabric Origins and Apoli datapacks and extract them into
-   `run/datapacks/`. See [`datapacks/README.md`](datapacks/README.md) for links and
-   detailed instructions.
+1. Download the latest Fabric Origins datapack zip and drop it into
+   `external/fabric-origins-zips/`. The Gradle task automatically extracts the newest zip
+   in that folder into `run/datapacks/origins-fabric/`.
 2. Launch the audit-enabled dev instance:
 
-   ```bash
-   ./gradlew runAudit
-   ```
-
-   The `runAudit` configuration sets the username to `DevAudit`, enables the
-   `origins.debugAudit` system property, and uses the shared `run/` workspace so datapacks
-   are detected automatically.
-3. Once the game finishes loading, execute the following commands in-game or from the
-   dedicated server console:
-
-   ```bash
+   ```powershell
+   # Drop latest zip into external/fabric-origins-zips/
+   .\gradlew.bat runAudit
    /reload
    /origins debug parity
    /origins debug todo
    ```
 
-   The debug commands create `run/debug/parity_report.json` and
-   `run/debug/parity_todo.json`.
+   The `runAudit` configuration sets the username to `DevAudit`, enables the
+   `origins.debugAudit` system property, and uses the shared `run/` workspace so datapacks
+   are detected automatically.
+   On non-Windows platforms you can use `./gradlew runAudit` and run the debug commands
+   manually once the game starts.
+3. Once the game finishes loading, execute the `/reload`, `/origins debug parity`, and
+   `/origins debug todo` commands in-game or from the dedicated server console. The debug
+   commands create `run/debug/parity_report.json` and `run/debug/parity_todo.json`.
 4. Copy the generated JSON files into the tracked `reports/parity/` directory before
    committing changes:
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.util.zip.ZipFile
+
 plugins {
     id 'java'
     id 'net.neoforged.gradle.userdev' version '7.0.190'
@@ -28,6 +30,33 @@ runs {
         args '--username', 'DevAudit'
         property 'origins.debugAudit', 'true'
     }
+}
+
+tasks.register("extractFabricDatapack") {
+    doLast {
+        def zips = file("${projectDir}/external/fabric-origins-zips").listFiles()?.findAll { it.name.endsWith(".zip") }
+        if (!zips || zips.isEmpty()) {
+            throw new GradleException("No Origins zip found in external/fabric-origins-zips/")
+        }
+        def latestZip = zips.sort { -it.lastModified() }.first()
+        println "Extracting datapack from ${latestZip.name}"
+
+        copy {
+            from(zipTree(latestZip)) {
+                include "*/src/main/resources/**"
+            }
+            into("${projectDir}/run/datapacks/origins-fabric")
+            eachFile { details ->
+                // Drop top-level folder segments like origins-fabric-1.21.x-dev/
+                details.relativePath = new RelativePath(true, details.relativePath.segments.drop(3))
+            }
+            includeEmptyDirs = false
+        }
+    }
+}
+
+tasks.named("runAudit") {
+    dependsOn("extractFabricDatapack")
 }
 
 sourceSets {


### PR DESCRIPTION
## Summary
- add a Gradle task that extracts the most recent Fabric Origins zip into `run/datapacks/origins-fabric/` before `runAudit`
- document the new zip-drop workflow in the README and contributing guide
- ignore the new `external/fabric-origins-zips/` drop folder in git

## Testing
- `./gradlew extractFabricDatapack --console=plain` *(fails: existing runAudit configuration in NeoGradle reports `taskName`/run type errors before tasks execute)*

------
https://chatgpt.com/codex/tasks/task_e_68e2189d9fc88327bd6d18834f8787c0