### PR TITLE
Add automated parity report archiving

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ Auditing parity changes requires the latest Fabric Origins datapack. Drop the ne
 
 Only the most recent zip in the folder is extracted. Gradle unpacks the datapack into `run/datapacks/origins-fabric/` automatically before the client launches.
 
+When the session ends, the build copies any `parity_report.json` and `parity_todo.json` files from `run/debug/` into `reports/parity/`. Review the archived reports and include them in your pull request so parity progress stays version-controlled.
+
 ## Submitting Your Pull Request
 
 - Provide clear descriptions of the changes made and the testing performed.

--- a/README.md
+++ b/README.md
@@ -92,16 +92,10 @@ audit tooling and collects reports for review. Follow this workflow to produce a
 3. Once the game finishes loading, execute the `/reload`, `/origins debug parity`, and
    `/origins debug todo` commands in-game or from the dedicated server console. The debug
    commands create `run/debug/parity_report.json` and `run/debug/parity_todo.json`.
-4. Copy the generated JSON files into the tracked `reports/parity/` directory before
-   committing changes:
-
-   ```bash
-   cp run/debug/parity_report.json reports/parity/
-   cp run/debug/parity_todo.json reports/parity/
-   ```
-
-   Upload the refreshed `parity_todo.json` along with your pull request so reviewers can
-   analyse the outstanding compatibility work.
+4. The build automatically archives any generated parity reports into
+   `reports/parity/` once `runAudit` exits. Review the refreshed JSON files and commit
+   them alongside your changes so reviewers can analyse the outstanding compatibility
+   work.
 
 ## Updating Minecraft or NeoForge versions
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,30 @@ tasks.register("extractFabricDatapack") {
     }
 }
 
+tasks.register("archiveParityReports") {
+    doLast {
+        def reportDir = file("${projectDir}/run/debug")
+        def targetDir = file("${projectDir}/reports/parity")
+        targetDir.mkdirs()
+
+        ["parity_report.json", "parity_todo.json"].each { fname ->
+            def f = new File(reportDir, fname)
+            if (f.exists()) {
+                copy {
+                    from(f)
+                    into(targetDir)
+                }
+                println "Archived ${fname} to reports/parity/"
+            } else {
+                println "No ${fname} found in run/debug/"
+            }
+        }
+    }
+}
+
 tasks.named("runAudit") {
     dependsOn("extractFabricDatapack")
+    finalizedBy("archiveParityReports")
 }
 
 sourceSets {


### PR DESCRIPTION
## Summary
- add an archiveParityReports Gradle task that copies generated parity JSONs into reports/parity/
- ensure runAudit finalizes by archiving and keep the parity reports directory tracked
- document the automated report archiving workflow in README and CONTRIBUTING

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e21a0408a08327ac9c4eaed759b980