### PR TITLE
Add runAudit run configuration for audit pipeline

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,10 @@ dependencies {
 
 runs {
     runAudit {
-        workingDirectory project.file('run')
-        taskName 'runAudit'
-        args '--username', 'DevAudit'
-        property 'origins.debugAudit', 'true'
+        client()
+        workingDirectory project.file("run")
+        property "origins.debugAudit", "true"
+        args "--username", "AuditUser"
     }
 }
 


### PR DESCRIPTION
## Summary
- define a runAudit configuration that inherits the client run setup and enables auditing flags for the pipeline

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e21bceedac832791d03b255e338304