### PR TITLE
Fix runAudit run configuration for NeoGradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ runs {
     runAudit {
         client()
         workingDirectory project.file("run")
-        property "origins.debugAudit", "true"
-        args "--username", "AuditUser"
+        systemProperty "origins.debugAudit", "true"
+        programArgs "--username", "AuditUser"
     }
 }
 


### PR DESCRIPTION
## Summary
- update the runAudit run configuration to use NeoGradle-compatible systemProperty and programArgs declarations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e21d8c18bc8327a95c4e3f1667475d