### PR TITLE
Fix runAudit run configuration for NeoGradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ runs {
         // JVM system property for Origins auditing
         systemProperty "origins.debugAudit", "true"
 
-        // Minecraft runtime args
-        args "--username", "AuditUser"
+        // Runtime arguments for the Minecraft client (property assignment)
+        programArguments = ["--username", "AuditUser"]
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the runAudit args call with programArguments assignment to comply with NeoGradle 7
- keep the Origins audit JVM property configuration intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2bdaa7a988327b9a25160d86d4763