### PR TITLE
Add Stonecutter multi-version configuration for NeoForge 1.21.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Origins (NeoForge)
 
 This repository contains the NeoForge build logic for the **Origins** mod. The project
-targets Minecraft **1.21.1** on NeoForge **21.1.209** and is configured to build
-with Gradle **8.13** and a Java **21** toolchain.
+is configured with the Stonecutter multi-version plugin and targets Minecraft
+**1.21.1** through **1.21.10** on the matching NeoForge **21.1.x** → **21.10.x** line.
+Builds continue to use Gradle **8.13** with a Java **21** toolchain.
 
 ## Requirements
 
@@ -10,12 +11,35 @@ with Gradle **8.13** and a Java **21** toolchain.
   installation is still required for Gradle to download the matching version).
 * Gradle Wrapper (included); invoke the wrapper scripts instead of a system Gradle.
 
+## Selecting a Minecraft/NeoForge variant
+
+Stonecutter maintains the Minecraft/NeoForge matrix described in `stonecutter.json`.
+Use the helper task to pick a target before building or running the project:
+
+```bash
+./gradlew stonecutterSwitchTo1.21.1-neoforge
+./gradlew --console=plain build
+```
+
+To build against the latest entry in the matrix run:
+
+```bash
+./gradlew stonecutterSwitchTo1.21.10-neoforge
+./gradlew --console=plain build
+```
+
+Once a variant is selected you can invoke any other Gradle goal (for example
+`./gradlew runClient`) and Stonecutter will reuse the active configuration.
+If you prefer the interactive CLI (`./gradlew stonecutter use <variant>`), be
+aware that Groovy DSL builds occasionally report ambiguous task names—use the
+explicit `stonecutterSwitchTo…` tasks shown above if that occurs.
+
 ## Building from source
 
 1. Clone the repository.
-2. (Optional) Update the values in `gradle.properties` to customise the mod metadata or
-   target versions.
-3. Run the build using the Gradle wrapper:
+2. (Optional) Adjust the default variant or metadata by editing `stonecutter.json` and
+   `gradle.properties`.
+3. Run the build using the Gradle wrapper (after selecting a variant as shown above):
 
    ```bash
    ./gradlew --console=plain build
@@ -99,12 +123,12 @@ audit tooling and collects reports for review. Follow this workflow to produce a
 
 ## Updating Minecraft or NeoForge versions
 
-The default Minecraft and NeoForge versions are controlled by the `minecraftVersion` and
-`neoForgeVersion` entries in `gradle.properties`. When bumping either value, also update
-the corresponding version ranges (`minecraftVersionRange`, `neoForgeVersionRange`) so the
-generated `neoforge.mods.toml` continues to match the desired compatibility matrix.
+The Stonecutter matrix in `stonecutter.json` controls which Minecraft/NeoForge pairs are
+available. Add a new entry (or update an existing one) with the desired `mcVersion` and
+`loaderVersion`, then rerun `./gradlew stonecutter use <variant>` to regenerate the
+Gradle properties and resources.
 
-If you need to produce builds for multiple Minecraft releases, the `versions/` directory
-contains per-version resource overrides. Add or adjust files within the appropriate
-sub-directory to customise metadata or assets for that specific target before packaging
-them separately.
+`gradle.properties` now stores token placeholders that Stonecutter resolves per variant.
+Only the metadata values such as `mod_id` or `mod_version` should be edited manually.
+Resource files that depend on versioned values live alongside `.stonecutter` templates in
+`src/main/resources`.

--- a/build.gradle
+++ b/build.gradle
@@ -19,70 +19,72 @@ repositories {
 }
 
 dependencies {
-    implementation "net.neoforged:neoforge:${property('neoforgeVersion')}"
+    implementation "net.neoforged:neoforge:${property('neoForgeVersion')}"
     implementation 'com.google.guava:guava:31.1-jre'
 }
 
-runs {
-    runAudit {
-        client() // inherit from the client run config
-        workingDirectory project.file("run")
+if (project == rootProject) {
+    runs {
+        runAudit {
+            client() // inherit from the client run config
+            workingDirectory project.file("run")
 
-        // JVM system property for Origins auditing
-        systemProperty "origins.debugAudit", "true"
+            // JVM system property for Origins auditing
+            systemProperty "origins.debugAudit", "true"
 
-        // Runtime arguments for the Minecraft client (property assignment)
-        programArguments = ["--username", "AuditUser"]
-    }
-}
-
-tasks.register("extractFabricDatapack") {
-    doLast {
-        def zips = file("${projectDir}/external/fabric-origins-zips").listFiles()?.findAll { it.name.endsWith(".zip") }
-        if (!zips || zips.isEmpty()) {
-            throw new GradleException("No Origins zip found in external/fabric-origins-zips/")
-        }
-        def latestZip = zips.sort { -it.lastModified() }.first()
-        println "Extracting datapack from ${latestZip.name}"
-
-        copy {
-            from(zipTree(latestZip)) {
-                include "*/src/main/resources/**"
-            }
-            into("${projectDir}/run/datapacks/origins-fabric")
-            eachFile { details ->
-                // Drop top-level folder segments like origins-fabric-1.21.x-dev/
-                details.relativePath = new RelativePath(true, details.relativePath.segments.drop(3))
-            }
-            includeEmptyDirs = false
+            // Runtime arguments for the Minecraft client (property assignment)
+            programArguments = ["--username", "AuditUser"]
         }
     }
-}
 
-tasks.register("archiveParityReports") {
-    doLast {
-        def reportDir = file("${projectDir}/run/debug")
-        def targetDir = file("${projectDir}/reports/parity")
-        targetDir.mkdirs()
+    tasks.register("extractFabricDatapack") {
+        doLast {
+            def zips = file("${projectDir}/external/fabric-origins-zips").listFiles()?.findAll { it.name.endsWith(".zip") }
+            if (!zips || zips.isEmpty()) {
+                throw new GradleException("No Origins zip found in external/fabric-origins-zips/")
+            }
+            def latestZip = zips.sort { -it.lastModified() }.first()
+            println "Extracting datapack from ${latestZip.name}"
 
-        ["parity_report.json", "parity_todo.json"].each { fname ->
-            def f = new File(reportDir, fname)
-            if (f.exists()) {
-                copy {
-                    from(f)
-                    into(targetDir)
+            copy {
+                from(zipTree(latestZip)) {
+                    include "*/src/main/resources/**"
                 }
-                println "Archived ${fname} to reports/parity/"
-            } else {
-                println "No ${fname} found in run/debug/"
+                into("${projectDir}/run/datapacks/origins-fabric")
+                eachFile { details ->
+                    // Drop top-level folder segments like origins-fabric-1.21.x-dev/
+                    details.relativePath = new RelativePath(true, details.relativePath.segments.drop(3))
+                }
+                includeEmptyDirs = false
             }
         }
     }
-}
 
-tasks.named("runAudit") {
-    dependsOn("extractFabricDatapack")
-    finalizedBy("archiveParityReports")
+    tasks.register("archiveParityReports") {
+        doLast {
+            def reportDir = file("${projectDir}/run/debug")
+            def targetDir = file("${projectDir}/reports/parity")
+            targetDir.mkdirs()
+
+            ["parity_report.json", "parity_todo.json"].each { fname ->
+                def f = new File(reportDir, fname)
+                if (f.exists()) {
+                    copy {
+                        from(f)
+                        into(targetDir)
+                    }
+                    println "Archived ${fname} to reports/parity/"
+                } else {
+                    println "No ${fname} found in run/debug/"
+                }
+            }
+        }
+    }
+
+    tasks.named("runAudit") {
+        dependsOn("extractFabricDatapack")
+        finalizedBy("archiveParityReports")
+    }
 }
 
 sourceSets {
@@ -94,14 +96,18 @@ sourceSets {
 }
 
 tasks.processResources {
+    def packFormat = project.findProperty('packFormat') ?: '48'
     def modProps = [
         mod_id: project.findProperty('mod_id') ?: 'origins',
         mod_version: project.findProperty('mod_version') ?: '0.1.0',
         mod_mc: project.findProperty('minecraftVersion') ?: '1.21.1'
     ]
-    inputs.properties(modProps)
+    inputs.properties(modProps + [PACK_FORMAT: packFormat])
     filesMatching('META-INF/neoforge.mods.toml') {
         expand(modProps)
+    }
+    filesMatching('pack.mcmeta') {
+        expand([PACK_FORMAT: packFormat])
     }
 }
 
@@ -115,3 +121,4 @@ tasks.withType(JavaCompile).configureEach {
         "-Xlint:-serial"       // suppress serialVersionUID noise for data classes
     ]
 }
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
 org.gradle.jvmargs=-Xmx2G -Dfile.encoding=UTF-8
 mod_id=origins
 mod_version=0.1.0
-minecraftVersion=1.21.1
-neoforgeVersion=21.1.209
+minecraftVersion=${minecraft}
+neoForgeVersion=${neoforge}
+packFormat=${PACK_FORMAT}
+loaderFile=${LOADER_FILE}

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,4 +5,13 @@ pluginManagement {
         mavenCentral()
     }
 }
+
+plugins {
+    id 'dev.kikugie.stonecutter' version '0.7.10'
+}
+
+stonecutter {
+    create(rootProject, file('stonecutter.json'))
+}
+
 rootProject.name = 'origins-neoforge'

--- a/src/main/resources/META-INF/neoforge.mods.toml.stonecutter
+++ b/src/main/resources/META-INF/neoforge.mods.toml.stonecutter
@@ -1,3 +1,4 @@
+# Stonecutter target: ${LOADER_FILE}
 modLoader="neoforge"
 loaderVersion="[21,)"
 license="MIT"

--- a/src/main/resources/pack.mcmeta.stonecutter
+++ b/src/main/resources/pack.mcmeta.stonecutter
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 34,
+    "pack_format": ${PACK_FORMAT},
     "description": "Origins NeoForge resources"
   }
 }

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    id("dev.kikugie.stonecutter")
+}
+
+stonecutter active "1.21.10-neoforge"

--- a/stonecutter.json
+++ b/stonecutter.json
@@ -1,0 +1,115 @@
+{
+  "default": "1.21.1-neoforge",
+  "versions": [
+    {
+      "project": "1.21.1-neoforge",
+      "version": "1.21.1",
+      "loader": "neoforge",
+      "loaderVersion": "21.1.209",
+      "mcVersion": "1.21.1",
+      "vars": {
+        "PACK_FORMAT": "48",
+        "LOADER_FILE": "neoforge.mods.toml"
+      }
+    },
+    {
+      "project": "1.21.2-neoforge",
+      "version": "1.21.2",
+      "loader": "neoforge",
+      "loaderVersion": "21.2.1-beta",
+      "mcVersion": "1.21.2",
+      "vars": {
+        "PACK_FORMAT": "48",
+        "LOADER_FILE": "neoforge.mods.toml"
+      }
+    },
+    {
+      "project": "1.21.3-neoforge",
+      "version": "1.21.3",
+      "loader": "neoforge",
+      "loaderVersion": "21.3.93",
+      "mcVersion": "1.21.3",
+      "vars": {
+        "PACK_FORMAT": "48",
+        "LOADER_FILE": "neoforge.mods.toml"
+      }
+    },
+    {
+      "project": "1.21.4-neoforge",
+      "version": "1.21.4",
+      "loader": "neoforge",
+      "loaderVersion": "21.4.154",
+      "mcVersion": "1.21.4",
+      "vars": {
+        "PACK_FORMAT": "48",
+        "LOADER_FILE": "neoforge.mods.toml"
+      }
+    },
+    {
+      "project": "1.21.5-neoforge",
+      "version": "1.21.5",
+      "loader": "neoforge",
+      "loaderVersion": "21.5.95",
+      "mcVersion": "1.21.5",
+      "vars": {
+        "PACK_FORMAT": "48",
+        "LOADER_FILE": "neoforge.mods.toml"
+      }
+    },
+    {
+      "project": "1.21.6-neoforge",
+      "version": "1.21.6",
+      "loader": "neoforge",
+      "loaderVersion": "21.6.9-beta",
+      "mcVersion": "1.21.6",
+      "vars": {
+        "PACK_FORMAT": "48",
+        "LOADER_FILE": "neoforge.mods.toml"
+      }
+    },
+    {
+      "project": "1.21.7-neoforge",
+      "version": "1.21.7",
+      "loader": "neoforge",
+      "loaderVersion": "21.7.9-beta",
+      "mcVersion": "1.21.7",
+      "vars": {
+        "PACK_FORMAT": "48",
+        "LOADER_FILE": "neoforge.mods.toml"
+      }
+    },
+    {
+      "project": "1.21.8-neoforge",
+      "version": "1.21.8",
+      "loader": "neoforge",
+      "loaderVersion": "21.8.47",
+      "mcVersion": "1.21.8",
+      "vars": {
+        "PACK_FORMAT": "48",
+        "LOADER_FILE": "neoforge.mods.toml"
+      }
+    },
+    {
+      "project": "1.21.9-neoforge",
+      "version": "1.21.9",
+      "loader": "neoforge",
+      "loaderVersion": "21.9.9-beta",
+      "mcVersion": "1.21.9",
+      "vars": {
+        "PACK_FORMAT": "48",
+        "LOADER_FILE": "neoforge.mods.toml"
+      }
+    },
+    {
+      "project": "1.21.10-neoforge",
+      "version": "1.21.10",
+      "loader": "neoforge",
+      "loaderVersion": "21.10.1-beta",
+      "mcVersion": "1.21.10",
+      "vars": {
+        "PACK_FORMAT": "48",
+        "LOADER_FILE": "neoforge.mods.toml"
+      }
+    }
+  ]
+}

--- a/versions/1.21.1-neoforge/gradle.properties
+++ b/versions/1.21.1-neoforge/gradle.properties
@@ -1,0 +1,8 @@
+minecraft=1.21.1
+neoforge=21.1.209
+minecraftVersion=1.21.1
+neoForgeVersion=21.1.209
+packFormat=48
+loaderFile=neoforge.mods.toml
+PACK_FORMAT=48
+LOADER_FILE=neoforge.mods.toml

--- a/versions/1.21.10-neoforge/gradle.properties
+++ b/versions/1.21.10-neoforge/gradle.properties
@@ -1,0 +1,8 @@
+minecraft=1.21.10
+neoforge=21.10.1-beta
+minecraftVersion=1.21.10
+neoForgeVersion=21.10.1-beta
+packFormat=48
+loaderFile=neoforge.mods.toml
+PACK_FORMAT=48
+LOADER_FILE=neoforge.mods.toml

--- a/versions/1.21.2-neoforge/gradle.properties
+++ b/versions/1.21.2-neoforge/gradle.properties
@@ -1,0 +1,8 @@
+minecraft=1.21.2
+neoforge=21.2.1-beta
+minecraftVersion=1.21.2
+neoForgeVersion=21.2.1-beta
+packFormat=48
+loaderFile=neoforge.mods.toml
+PACK_FORMAT=48
+LOADER_FILE=neoforge.mods.toml

--- a/versions/1.21.3-neoforge/gradle.properties
+++ b/versions/1.21.3-neoforge/gradle.properties
@@ -1,0 +1,8 @@
+minecraft=1.21.3
+neoforge=21.3.93
+minecraftVersion=1.21.3
+neoForgeVersion=21.3.93
+packFormat=48
+loaderFile=neoforge.mods.toml
+PACK_FORMAT=48
+LOADER_FILE=neoforge.mods.toml

--- a/versions/1.21.4-neoforge/gradle.properties
+++ b/versions/1.21.4-neoforge/gradle.properties
@@ -1,0 +1,8 @@
+minecraft=1.21.4
+neoforge=21.4.154
+minecraftVersion=1.21.4
+neoForgeVersion=21.4.154
+packFormat=48
+loaderFile=neoforge.mods.toml
+PACK_FORMAT=48
+LOADER_FILE=neoforge.mods.toml

--- a/versions/1.21.5-neoforge/gradle.properties
+++ b/versions/1.21.5-neoforge/gradle.properties
@@ -1,0 +1,8 @@
+minecraft=1.21.5
+neoforge=21.5.95
+minecraftVersion=1.21.5
+neoForgeVersion=21.5.95
+packFormat=48
+loaderFile=neoforge.mods.toml
+PACK_FORMAT=48
+LOADER_FILE=neoforge.mods.toml

--- a/versions/1.21.6-neoforge/gradle.properties
+++ b/versions/1.21.6-neoforge/gradle.properties
@@ -1,0 +1,8 @@
+minecraft=1.21.6
+neoforge=21.6.9-beta
+minecraftVersion=1.21.6
+neoForgeVersion=21.6.9-beta
+packFormat=48
+loaderFile=neoforge.mods.toml
+PACK_FORMAT=48
+LOADER_FILE=neoforge.mods.toml

--- a/versions/1.21.7-neoforge/gradle.properties
+++ b/versions/1.21.7-neoforge/gradle.properties
@@ -1,0 +1,8 @@
+minecraft=1.21.7
+neoforge=21.7.9-beta
+minecraftVersion=1.21.7
+neoForgeVersion=21.7.9-beta
+packFormat=48
+loaderFile=neoforge.mods.toml
+PACK_FORMAT=48
+LOADER_FILE=neoforge.mods.toml

--- a/versions/1.21.8-neoforge/gradle.properties
+++ b/versions/1.21.8-neoforge/gradle.properties
@@ -1,0 +1,8 @@
+minecraft=1.21.8
+neoforge=21.8.47
+minecraftVersion=1.21.8
+neoForgeVersion=21.8.47
+packFormat=48
+loaderFile=neoforge.mods.toml
+PACK_FORMAT=48
+LOADER_FILE=neoforge.mods.toml

--- a/versions/1.21.9-neoforge/gradle.properties
+++ b/versions/1.21.9-neoforge/gradle.properties
@@ -1,0 +1,8 @@
+minecraft=1.21.9
+neoforge=21.9.9-beta
+minecraftVersion=1.21.9
+neoForgeVersion=21.9.9-beta
+packFormat=48
+loaderFile=neoforge.mods.toml
+PACK_FORMAT=48
+LOADER_FILE=neoforge.mods.toml


### PR DESCRIPTION
```txt
Summary:
- integrate the Stonecutter plugin in the Gradle settings and define a 1.21.1–1.21.10 NeoForge matrix in stonecutter.json.
- parameterize Gradle properties/build logic for Stonecutter tokens and convert pack/neoforge metadata into .stonecutter templates.
- document the workflow in the README and add per-variant gradle.properties files under versions/.

Testing:
- ./gradlew --console=plain stonecutterSwitchTo1.21.1-neoforge
- ./gradlew --console=plain build (fails: NeoForm supplyRawJarFor… is missing the expected joined jar in this environment)
- ./gradlew --console=plain stonecutterSwitchTo1.21.7-neoforge
- ./gradlew --console=plain build (fails: NeoForm supplyRawJarFor… is missing the expected joined jar in this environment)
- ./gradlew --console=plain stonecutterSwitchTo1.21.10-neoforge
- ./gradlew --console=plain build (fails: NeoForm supplyRawJarFor… is missing the expected joined jar in this environment)
```

------
https://chatgpt.com/codex/tasks/task_b_68e6852e9a48832fa17f986e20aab327